### PR TITLE
feat: refresh track editor on selection change

### DIFF
--- a/main.js
+++ b/main.js
@@ -114,6 +114,11 @@ function refreshAndSelect(i = selectedTrackIndex){
   renderParamsPanel();
 }
 
+trackSel.onchange = () => {
+  selectedTrackIndex = parseInt(trackSel.value, 10);
+  refreshAndSelect(selectedTrackIndex);
+};
+
 /* ---------- Patterns ---------- */
 function refreshPatternSelect() {
   patternSel.innerHTML = '';


### PR DESCRIPTION
## Summary
- refresh editor and parameters when the user picks a different track

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c82a272178832dbeb720a525878259