### PR TITLE
Fix track addition not updating dropdown

### DIFF
--- a/main.js
+++ b/main.js
@@ -119,6 +119,15 @@ trackSel.onchange = () => {
   refreshAndSelect(selectedTrackIndex);
 };
 
+addTrackBtn.onclick = () => {
+  const eng = engineSel.value || 'synth';
+  const name = `Track ${tracks.length + 1}`;
+  tracks.push(normalizeTrack(createTrack(name, eng, 16)));
+  selectedTrackIndex = tracks.length - 1;
+  applyMixer(tracks);
+  refreshAndSelect(selectedTrackIndex);
+};
+
 /* ---------- Patterns ---------- */
 function refreshPatternSelect() {
   patternSel.innerHTML = '';


### PR DESCRIPTION
## Summary
- Hook up the add track button to create a new track
- Refresh track selector after adding tracks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c82b73c48c832d926ef78222c4ed75