### PR TITLE
Add piano roll toggle handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -110,6 +110,7 @@ function refreshAndSelect(i = selectedTrackIndex){
   normalizeTrack(currentTrack());
   refreshTrackSelect(trackSel, tracks, i);
   engineSel.value = currentTrack().engine;
+  togglePiano.checked = currentTrack().mode === 'piano';
   showEditorForTrack();
   renderParamsPanel();
 }
@@ -117,6 +118,12 @@ function refreshAndSelect(i = selectedTrackIndex){
 trackSel.onchange = () => {
   selectedTrackIndex = parseInt(trackSel.value, 10);
   refreshAndSelect(selectedTrackIndex);
+};
+
+togglePiano.onchange = () => {
+  currentTrack().mode = togglePiano.checked ? 'piano' : 'steps';
+  showEditorForTrack();
+  paintPlayhead();
 };
 
 addTrackBtn.onclick = () => {


### PR DESCRIPTION
## Summary
- Sync piano roll toggle with track mode
- Rebuild editor and playhead when toggling

## Testing
- ⚠️ `node --version` *(command not found: node)*

------
https://chatgpt.com/codex/tasks/task_e_68c82eadb12c832d8e49772c0289b453