### PR TITLE
Allow switching track type

### DIFF
--- a/main.js
+++ b/main.js
@@ -120,6 +120,11 @@ trackSel.onchange = () => {
   refreshAndSelect(selectedTrackIndex);
 };
 
+engineSel.onchange = () => {
+  currentTrack().engine = engineSel.value;
+  refreshAndSelect(selectedTrackIndex);
+};
+
 togglePiano.onchange = () => {
   currentTrack().mode = togglePiano.checked ? 'piano' : 'steps';
   showEditorForTrack();


### PR DESCRIPTION
## Summary
- Update engine selection dropdown to change the engine of the currently selected track

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c830105510832d8366d969b6176fc9