### PR TITLE
Remove velocity slider from step grid

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,12 +64,6 @@ const stepGrid = createGrid(
     st.on = !st.on;
     st.vel = st.on ? 1 : 0;
     renderCurrentEditor();
-  },
-  (i, v) => { // drag for velocity
-    const st = currentTrack().steps[i];
-    if (v < 0.15) { st.on = false; st.vel = 0; }
-    else { st.on = true; st.vel = v; }
-    renderCurrentEditor();
   }
 );
 

--- a/sequencer.js
+++ b/sequencer.js
@@ -4,7 +4,7 @@
  * Build the step grid UI for ONE visible track.
  * You can change its length later via setLength().
  */
-export function createGrid(seqEl, onToggle, onSetVel, onDoubleToggle) {
+export function createGrid(seqEl, onToggle, onDoubleToggle) {
   let gridCells = [];
   let currentLen = 16;
 
@@ -17,10 +17,6 @@ export function createGrid(seqEl, onToggle, onSetVel, onDoubleToggle) {
       const cell = document.createElement('div');
       cell.className = 'cell';
       cell.dataset.index = i;
-
-      const velBar = document.createElement('div');
-      velBar.className = 'vel';
-      cell.appendChild(velBar);
 
       // --- Double-click/tap handling ---
       let lastTap = 0;
@@ -48,18 +44,6 @@ export function createGrid(seqEl, onToggle, onSetVel, onDoubleToggle) {
           onToggle(i);
         }
       });
-
-      // Drag velocity
-      let dragging=false, startY=0;
-      const setFromY = (y)=>{
-        const dy = (startY - y); // up = louder
-        const v = Math.max(0.0, Math.min(1.0, 0.5 + dy/120));
-        onSetVel(i, v);
-      };
-      cell.addEventListener('pointerdown', (e)=>{ dragging=true; startY=e.clientY; cell.setPointerCapture(e.pointerId); });
-      cell.addEventListener('pointermove', (e)=>{ if(dragging) setFromY(e.clientY); });
-      cell.addEventListener('pointerup',   (e)=>{ dragging=false; try{ cell.releasePointerCapture(e.pointerId);}catch{} });
-
       seqEl.appendChild(cell);
       gridCells.push(cell);
     }
@@ -70,8 +54,6 @@ export function createGrid(seqEl, onToggle, onSetVel, onDoubleToggle) {
       const st = getStep(i);
       const cell = gridCells[i];
       cell.classList.toggle('on', !!st?.on);
-      const bar = cell.querySelector('.vel');
-      if (bar) bar.style.height = st?.on ? Math.round((st.vel || 0)*100)+'%' : '0';
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the per-step velocity bar and drag handler from the sequencer grid so steps behave as simple toggles
- simplify the step editor wiring to drop the velocity-adjust callback and keep full velocity when enabling a step

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c83c8823d8832da27450f652a8abb8