### PR TITLE
Add modulation engine and scheduler integration

### DIFF
--- a/mods.js
+++ b/mods.js
@@ -1,0 +1,99 @@
+import { ctx } from './core.js';
+
+const TAU = Math.PI * 2;
+
+function wrapPhase(v = 0) {
+  const frac = v % 1;
+  return frac < 0 ? frac + 1 : frac;
+}
+
+const LFO_SHAPES = {
+  sine: (phase) => Math.sin(phase * TAU),
+  triangle: (phase) => 1 - 4 * Math.abs(0.5 - (phase % 1)),
+  square: (phase) => ((phase % 1) < 0.5 ? 1 : -1),
+  saw: (phase) => ((phase % 1) * 2) - 1,
+  ramp: (phase) => ((phase % 1) * 2) - 1,
+};
+
+function evaluateLfo(mod) {
+  const opts = mod?.options || {};
+  const now = (ctx?.currentTime ?? (performance.now() / 1000));
+  const state = mod._state || (mod._state = {
+    phase: wrapPhase(opts.phase ?? 0),
+    lastTime: now,
+  });
+
+  const rate = Number(opts.rate);
+  const freq = Number.isFinite(rate) ? Math.max(0, rate) : 1;
+  const elapsed = Math.max(0, now - (state.lastTime ?? now));
+  if (freq > 0) {
+    state.phase = wrapPhase(state.phase + elapsed * freq);
+  } else if (Number.isFinite(opts.phase)) {
+    state.phase = wrapPhase(opts.phase);
+  }
+  state.lastTime = now;
+
+  const shapeKey = typeof opts.shape === 'string' ? opts.shape.toLowerCase() : 'sine';
+  const shapeFn = LFO_SHAPES[shapeKey] || LFO_SHAPES.sine;
+  let value = shapeFn(state.phase);
+
+  if (opts.unipolar) value = (value + 1) / 2;
+  if (Number.isFinite(opts.bias)) value += opts.bias;
+  const depth = Number(opts.depth);
+  if (Number.isFinite(depth)) value *= depth;
+
+  return value;
+}
+
+const SOURCES = {
+  lfo: evaluateLfo,
+};
+
+function normalizeTarget(target) {
+  if (Array.isArray(target)) {
+    return target.map(t => `${t}`.trim()).filter(Boolean);
+  }
+  if (typeof target === 'string') {
+    return target.split('.').map(p => p.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function assignOffset(root, path, value) {
+  if (!Number.isFinite(value) || value === 0) return;
+  const parts = [...path];
+  const last = parts.pop();
+  if (!last) return;
+  let cursor = root;
+  for (const key of parts) {
+    if (!cursor[key] || typeof cursor[key] !== 'object') cursor[key] = {};
+    cursor = cursor[key];
+  }
+  const current = cursor[last];
+  cursor[last] = Number.isFinite(current) ? current + value : value;
+}
+
+export function applyMods(track) {
+  if (!track || !Array.isArray(track.mods) || !track.mods.length) return null;
+
+  const offsets = {};
+  let touched = false;
+
+  for (const mod of track.mods) {
+    if (!mod || typeof mod !== 'object') continue;
+    if (mod.enabled === false) continue;
+    const handler = SOURCES[mod.source];
+    if (!handler) continue;
+    const normalized = handler(track, mod);
+    const amount = Number(mod.amount);
+    if (!Number.isFinite(amount) || amount === 0) continue;
+    const delta = normalized * amount;
+    if (!Number.isFinite(delta) || delta === 0) continue;
+    const path = normalizeTarget(mod.target);
+    if (!path.length) continue;
+    assignOffset(offsets, path, delta);
+    touched = true;
+  }
+
+  return touched ? offsets : null;
+}


### PR DESCRIPTION
## Summary
- extend track creation to host modulation definitions and provide helpers for managing modulators
- add a modulation engine with LFO support that produces parameter offsets and serialize modulators with patterns
- apply modulation on every scheduler tick so engine parameters receive temporary offsets before triggering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c847d540e8832d818ab385927e7755