### PR TITLE
Add modulation rack UI for tracks

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,15 @@ h3 { margin:0 0 8px; font-weight:600; }
 .field label { display:block; font-size:12px; color:var(--muted); margin-bottom:4px; }
 .field .inline { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
 
+.mod-rack { margin:12px 0; display:flex; flex-direction:column; gap:10px; }
+.mod-row { display:flex; flex-wrap:wrap; gap:12px; align-items:flex-end; padding:10px; background:#14171f; border:1px solid var(--border); border-radius:10px; }
+.mod-cell { display:flex; flex-direction:column; gap:4px; min-width:120px; }
+.mod-cell span { font-size:12px; color:var(--muted); }
+.mod-row input, .mod-row select { min-width:110px; }
+.mod-row button { align-self:center; }
+.mod-actions { display:flex; }
+.mod-empty { color:var(--muted); font-size:12px; padding:2px 0; }
+
 #sequencer { display:grid; grid-template-columns: repeat(16, minmax(22px,1fr)); gap:6px; }
 .cell { position:relative; height:28px; background:#171a21; border:1px solid var(--border); border-radius:8px; }
 .cell.on { background:#1d293c; }


### PR DESCRIPTION
## Summary
- add a modulation rack renderer with source, rate, depth, and target controls bound to track modulators
- integrate the modulation rack into the track parameter panel and wire up add/remove actions
- add styling for the modulation rack rows so the controls align with the existing UI

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c84a140418832db4f72aa40f6ca700