### PR TITLE
Add Add LFO button to mod matrix

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,7 +20,7 @@ h3 { margin:0 0 8px; font-weight:600; }
 .mod-cell span { font-size:12px; color:var(--muted); }
 .mod-row input, .mod-row select { min-width:110px; }
 .mod-row button { align-self:center; }
-.mod-actions { display:flex; }
+.mod-actions { display:flex; gap:8px; flex-wrap:wrap; }
 .mod-empty { color:var(--muted); font-size:12px; padding:2px 0; }
 
 #sequencer { display:grid; grid-template-columns: repeat(16, minmax(22px,1fr)); gap:6px; }

--- a/ui.js
+++ b/ui.js
@@ -267,6 +267,22 @@ export function renderModulationRack(rootEl, track) {
 
   const mods = track.mods;
   const rerender = () => renderModulationRack(rootEl, track);
+  const addModWithDefaults = (extra = {}) => {
+    const { target: targetOverride, options: extraOptions, ...rest } = extra || {};
+    const options = getTargetOptionsForTrack(track);
+    const defaultTarget = targetOverride ?? options?.[0]?.value ?? '';
+    const mod = createModulator(track, {
+      source: 'lfo',
+      amount: 0,
+      target: defaultTarget,
+      options: { rate: 1, ...(extraOptions || {}) },
+      ...rest,
+    });
+    if (!mod.options || typeof mod.options !== 'object') mod.options = {};
+    if (mod.options.rate === undefined) mod.options.rate = 1;
+    rerender();
+    return mod;
+  };
 
   if (!mods.length) {
     const empty = document.createElement('div');
@@ -371,19 +387,18 @@ export function renderModulationRack(rootEl, track) {
   addBtn.className = 'ghost';
   addBtn.textContent = '+ Add Modulation';
   addBtn.onclick = () => {
-    const options = getTargetOptionsForTrack(track);
-    const defaultTarget = options?.[0]?.value || '';
-    const mod = createModulator(track, {
-      source: 'lfo',
-      amount: 0,
-      target: defaultTarget,
-      options: { rate: 1 },
-    });
-    if (!mod.options || typeof mod.options !== 'object') mod.options = { rate: 1 };
-    if (mod.options.rate === undefined) mod.options.rate = 1;
-    rerender();
+    addModWithDefaults();
   };
   actions.appendChild(addBtn);
+
+  const addLfoBtn = document.createElement('button');
+  addLfoBtn.type = 'button';
+  addLfoBtn.className = 'ghost';
+  addLfoBtn.textContent = '+ Add LFO';
+  addLfoBtn.onclick = () => {
+    addModWithDefaults({ source: 'lfo' });
+  };
+  actions.appendChild(addLfoBtn);
   rootEl.appendChild(actions);
 }
 


### PR DESCRIPTION
## Summary
- add a reusable helper for creating modulators with default settings and render a dedicated "+ Add LFO" control in the modulation rack
- tweak modulation action styling so multiple buttons have consistent spacing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9646f853c832d9e9a40ad54d2943d