### PR TITLE
Add freeform target toggle for modulation rack

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,6 +20,10 @@ h3 { margin:0 0 8px; font-weight:600; }
 .mod-cell span { font-size:12px; color:var(--muted); }
 .mod-row input, .mod-row select { min-width:110px; }
 .mod-row button { align-self:center; }
+.mod-target-controls { display:flex; align-items:center; gap:8px; }
+.mod-target-controls select,
+.mod-target-controls input { flex:1; min-width:140px; }
+.mod-target-controls .mod-target-toggle { align-self:auto; padding:4px 8px; font-size:12px; }
 .mod-actions { display:flex; gap:8px; flex-wrap:wrap; }
 .mod-empty { color:var(--muted); font-size:12px; padding:2px 0; }
 


### PR DESCRIPTION
## Summary
- add a toggle beside the modulation target control to switch between list and freeform entry while keeping values in sync
- persist the freeform mode flag on each modulator so pattern serialization restores the chosen target mode
- adjust modulation rack styles to align the new toggle and input with existing controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9da9d36d8832db44bdd527eebc2c4