### PR TITLE
Add advanced sampler toggle

### DIFF
--- a/main.js
+++ b/main.js
@@ -62,6 +62,23 @@ function normalizeTrack(t) {
     t.steps = Array.from({ length: t.length }, () => ({ on:false, vel:0 }));
   }
 
+  if (!t.params || typeof t.params !== 'object') t.params = {};
+  if (!t.params.sampler || typeof t.params.sampler !== 'object') {
+    t.params.sampler = { start:0, end:1, semis:0, gain:1, loop:false, advanced:false };
+  } else {
+    const sampler = t.params.sampler;
+    const toNumber = (value, fallback) => {
+      const num = Number(value);
+      return Number.isFinite(num) ? num : fallback;
+    };
+    sampler.start = toNumber(sampler.start, 0);
+    sampler.end = toNumber(sampler.end, 1);
+    sampler.semis = toNumber(sampler.semis, 0);
+    sampler.gain = toNumber(sampler.gain, 1);
+    sampler.loop = !!sampler.loop;
+    sampler.advanced = !!sampler.advanced;
+  }
+
   if (!Array.isArray(t.mods)) {
     t.mods = [];
   } else {

--- a/style.css
+++ b/style.css
@@ -14,6 +14,19 @@ h3 { margin:0 0 8px; font-weight:600; }
 .field label { display:block; font-size:12px; color:var(--muted); margin-bottom:4px; }
 .field .inline { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
 
+.sampler-advanced {
+  display:none;
+  margin:8px 0 0;
+  padding:10px;
+  border:1px dashed var(--border);
+  border-radius:10px;
+  background:#14171f;
+}
+
+.sampler-advanced.visible {
+  display:block;
+}
+
 .mod-rack { margin:12px 0; display:flex; flex-direction:column; gap:10px; }
 .mod-row { display:flex; flex-wrap:wrap; gap:12px; align-items:flex-end; padding:10px; background:#14171f; border:1px solid var(--border); border-radius:10px; }
 .mod-cell { display:flex; flex-direction:column; gap:4px; min-width:120px; }

--- a/tracks.js
+++ b/tracks.js
@@ -9,7 +9,7 @@ export const defaults = {
   snare808:{ tone:180, noise:0.6, decay:0.22 },
   hat808:  { decay:0.06, hpf:8000 },
   clap909: { bursts:3, spread:0.02, decay:0.10 },
-  sampler: { start:0, end:1, semis:0, gain:1, loop:false },
+  sampler: { start:0, end:1, semis:0, gain:1, loop:false, advanced:false },
 };
 
 const clone = o => JSON.parse(JSON.stringify(o));

--- a/ui.js
+++ b/ui.js
@@ -150,6 +150,12 @@ export function renderParams(containerEl, track, makeFieldHtml) {
     html += field('Semitones', `<input id="sam_semi" type="number" min="-24" max="24" step="1" value="${p.semis}">`);
     html += field('Gain',   `<input id="sam_gain"  type="range" min="0" max="2" step="0.01" value="${p.gain}">`);
     html += field('Loop',   `<button id="sam_loop" class="toggle ${p.loop?'active':''}">${p.loop ? 'On' : 'Off'}</button>`);
+    html += field('Advanced controls',
+      `<label class="ctrl"><input id="sam_adv" type="checkbox" ${p.advanced ? 'checked' : ''}> Enable advanced sampler</label>`,
+      'Show experimental sampler tools');
+    html += `<div id="sam_advPanel" class="sampler-advanced ${p.advanced ? 'visible' : ''}">
+      <div class="hint">Advanced sampler features will appear here.</div>
+    </div>`;
   }
 
   html += `<div class="badge">Modulation</div>`;
@@ -247,6 +253,8 @@ export function renderParams(containerEl, track, makeFieldHtml) {
       const semi= document.getElementById('sam_semi');
       const gIn = document.getElementById('sam_gain');
       const lBtn= document.getElementById('sam_loop');
+      const adv = document.getElementById('sam_adv');
+      const advPanel = document.getElementById('sam_advPanel');
 
       if (f && onSampleFile) f.onchange = (ev) => onSampleFile(ev.target.files?.[0] || null);
       if (sIn) sIn.oninput = e => { p.start = +e.target.value; };
@@ -254,6 +262,10 @@ export function renderParams(containerEl, track, makeFieldHtml) {
       if (semi)semi.oninput= e => { p.semis = +e.target.value; };
       if (gIn) gIn.oninput = e => { p.gain  = +e.target.value; };
       if (lBtn)lBtn.onclick= () => { p.loop = !p.loop; lBtn.classList.toggle('active', p.loop); lBtn.textContent = p.loop ? 'On' : 'Off'; };
+      if (adv) adv.onchange = (e) => {
+        p.advanced = !!e.target.checked;
+        if (advPanel) advPanel.classList.toggle('visible', p.advanced);
+      };
     }
   };
 }


### PR DESCRIPTION
## Summary
- add an "Advanced controls" toggle to the sampler parameter panel with a placeholder container for future tools
- persist the sampler's advanced flag via defaults and normalization so existing patterns stay compatible
- style the advanced sampler panel so it stays hidden until enabled

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9dc8ae4dc832da3bf9f04d27aca54