### PR TITLE
Add inline step editor to track params

### DIFF
--- a/main.js
+++ b/main.js
@@ -129,11 +129,17 @@ function renderCurrentEditor(){
   const t = currentTrack();
   if (t.mode === 'piano') piano.update();
   else stepGrid.update((i)=>t.steps[i]);
+  const inlineStep = paramsEl?._inlineStepEditor;
+  if (inlineStep && t && Array.isArray(t.steps)) {
+    inlineStep.update(t.steps);
+  }
 }
 function paintPlayhead(){
   const t = currentTrack();
   if (t.mode === 'piano') piano.paint(t.pos);
   else stepGrid.paint(t.pos);
+  const inlineStep = paramsEl?._inlineStepEditor;
+  if (inlineStep) inlineStep.paint(t.pos ?? -1);
 }
 
 /* ---------- Params ---------- */
@@ -190,18 +196,34 @@ async function onSampleFile(file) {
 }
 
 function renderParamsPanel(){
-  const binder = renderParams(paramsEl, currentTrack(), makeField);
+  const track = currentTrack();
+  const binder = renderParams(paramsEl, track, makeField);
   binder({
     applyMixer: () => applyMixer(tracks),
-    t: currentTrack(),
+    t: track,
     onStepsChange: (newLen) => {
-      resizeTrackSteps(currentTrack(), newLen);
-      normalizeTrack(currentTrack());
+      resizeTrackSteps(track, newLen);
+      normalizeTrack(track);
       showEditorForTrack();
       paintPlayhead();
+      const inlineStep = paramsEl?._inlineStepEditor;
+      if (inlineStep && Array.isArray(track.steps)) {
+        inlineStep.rebuild(track.length ?? track.steps.length);
+        inlineStep.update(track.steps);
+        inlineStep.paint(track.pos ?? -1);
+      }
     },
     onSampleFile,
+    onStepToggle: () => {
+      renderCurrentEditor();
+      paintPlayhead();
+    },
   });
+  const inlineStep = paramsEl?._inlineStepEditor;
+  if (inlineStep && track && Array.isArray(track.steps)) {
+    inlineStep.update(track.steps);
+    inlineStep.paint(track.pos ?? -1);
+  }
 }
 function refreshAndSelect(i = selectedTrackIndex){
   normalizeTrack(currentTrack());

--- a/style.css
+++ b/style.css
@@ -14,6 +14,14 @@ h3 { margin:0 0 8px; font-weight:600; }
 .field label { display:block; font-size:12px; color:var(--muted); margin-bottom:4px; }
 .field .inline { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
 
+.step-inline { display:flex; flex-wrap:wrap; gap:8px; align-items:flex-start; width:100%; }
+.step-inline select { min-width:72px; }
+.step-inline-grid { display:grid; flex:1; grid-template-columns: repeat(auto-fit, minmax(18px, 1fr)); gap:4px; }
+.step-inline-grid .mini-step { position:relative; width:100%; min-height:18px; aspect-ratio:1 / 1; border:1px solid var(--border); border-radius:6px; background:#171a21; padding:0; cursor:pointer; transition:background .12s ease, border-color .12s ease, box-shadow .12s ease; }
+.step-inline-grid .mini-step.on { background:#1d293c; }
+.step-inline-grid .mini-step.playhead { box-shadow:0 0 0 2px var(--accent); }
+.step-inline-grid .mini-step:focus-visible { outline:2px solid var(--accent); outline-offset:1px; }
+
 .sampler-advanced {
   display:none;
   margin:8px 0 0;


### PR DESCRIPTION
## Summary
- add an inline step editor beside the per-track step selector in the params panel
- keep the mini step grid in sync with track changes, playhead position, and length adjustments
- style the embedded step grid to match the existing sequencer look

## Testing
- Not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cbb5d4e0bc832db153b78dd6d8951b