### PR TITLE
Add per-step velocity params

### DIFF
--- a/sequencer.js
+++ b/sequencer.js
@@ -1,4 +1,5 @@
 // sequencer.js
+import { getStepVelocity } from './tracks.js';
 
 /**
  * Build the step grid UI for ONE visible track.
@@ -44,6 +45,11 @@ export function createGrid(seqEl, onToggle, onDoubleToggle, onSelect) {
       const cell = document.createElement('div');
       cell.className = 'cell';
       cell.dataset.index = i;
+
+      const velBar = document.createElement('div');
+      velBar.className = 'vel';
+      velBar.style.height = '0%';
+      cell.appendChild(velBar);
 
       // --- Double-click/tap handling ---
       let lastTap = 0;
@@ -131,6 +137,17 @@ export function createGrid(seqEl, onToggle, onDoubleToggle, onSelect) {
       const st = getStep(i);
       const cell = gridCells[i];
       cell.classList.toggle('on', !!st?.on);
+      const bar = cell.querySelector('.vel');
+      if (bar){
+        const vel = getStepVelocity(st, st?.on ? 1 : 0);
+        const clamped = Math.max(0, Math.min(1, vel));
+        bar.style.height = Math.round(clamped * 100) + '%';
+      }
+      if (cell){
+        const vel = getStepVelocity(st, 0);
+        const clamped = Math.max(0, Math.min(1, vel));
+        cell.title = `Step ${i + 1} • Vel ${Math.round(clamped * 127)}`;
+      }
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -25,6 +25,11 @@ h3 { margin:0 0 8px; font-weight:600; }
 .step-detail { flex:1 1 100%; display:flex; flex-wrap:wrap; align-items:center; gap:10px; padding:12px; border:1px dashed var(--border); border-radius:10px; background:#14171f; min-height:48px; }
 .step-detail.placeholder { justify-content:center; text-align:center; }
 .step-detail.placeholder .hint { width:100%; }
+.step-param-controls { display:flex; flex-wrap:wrap; align-items:center; gap:10px; width:100%; }
+.step-param-controls .step-param-slider { flex:1 1 160px; min-width:140px; }
+.step-param-controls .step-param-value { width:64px; padding:4px 6px; border-radius:8px; border:1px solid var(--border); background:#1a1d25; color:var(--fg); }
+.step-param-controls .step-param-value:focus { outline:2px solid var(--accent); outline-offset:1px; }
+.step-param-state { min-width:60px; text-transform:uppercase; font-size:11px; letter-spacing:0.04em; }
 
 .sampler-advanced {
   display:none;


### PR DESCRIPTION
## Summary
- add per-step parameter helpers so steps carry a velocity object and normalization keeps values in sync
- persist the new step params through pattern serialization/instantiation and refresh sequencer/inline indicators
- provide UI controls for editing velocity and apply it during playback with updated styling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc32f77d08832dba5200a4d052e71f