### PR TITLE
Add step FX support with sample & hold

### DIFF
--- a/patterns.js
+++ b/patterns.js
@@ -28,6 +28,7 @@ export function serializePattern(name, tracks, patternLen16 = 16) {
           on: !!normalized.on,
           vel: normalized.vel,
           params: clone(normalized.params),
+          fx: clone(normalized.fx),
         };
       }),
       mode: t.mode || 'steps',
@@ -65,6 +66,7 @@ export function instantiatePattern(pat, sampleCache = {}) {
       normalizedStep.on = !!source?.on;
       const velocity = getStepVelocity(source, normalizedStep.on ? 1 : 0);
       normalizedStep.params = clone(normalizedStep.params);
+      normalizedStep.fx = clone(normalizedStep.fx);
       setStepVelocity(normalizedStep, velocity);
       t.steps[i] = normalizedStep;
     }

--- a/tracks.js
+++ b/tracks.js
@@ -14,6 +14,122 @@ export const defaults = {
 
 const clone = o => JSON.parse(JSON.stringify(o));
 
+export const STEP_FX_TYPES = Object.freeze({
+  NONE: '',
+  SAMPLE_HOLD: 'sampleHold',
+});
+
+export const STEP_FX_DEFAULTS = Object.freeze({
+  [STEP_FX_TYPES.SAMPLE_HOLD]: Object.freeze({
+    target: '',
+    min: -0.25,
+    max: 0.25,
+    amount: 0.25,
+    chance: 1,
+    hold: 1,
+  }),
+});
+
+function cloneFxDefaults(type = STEP_FX_TYPES.NONE) {
+  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
+    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
+    return {
+      type,
+      config: {
+        target: defaults.target,
+        min: defaults.min,
+        max: defaults.max,
+        amount: defaults.amount,
+        chance: defaults.chance,
+        hold: defaults.hold,
+      },
+    };
+  }
+  return { type: STEP_FX_TYPES.NONE, config: {} };
+}
+
+export function normalizeStepFx(definition) {
+  if (!definition || typeof definition !== 'object') {
+    return cloneFxDefaults();
+  }
+
+  const type = typeof definition.type === 'string' ? definition.type.trim() : '';
+  if (!type || !(type in STEP_FX_DEFAULTS)) {
+    return cloneFxDefaults();
+  }
+
+  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
+    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
+    const source = definition.config && typeof definition.config === 'object'
+      ? definition.config
+      : {};
+
+    let min = Number(source.min);
+    if (!Number.isFinite(min)) {
+      const amount = Number(source.amount);
+      min = Number.isFinite(amount) ? -Math.abs(amount) : defaults.min;
+    }
+
+    let max = Number(source.max);
+    if (!Number.isFinite(max)) {
+      const amount = Number(source.amount);
+      max = Number.isFinite(amount) ? Math.abs(amount) : defaults.max;
+    }
+
+    if (min > max) {
+      const tmp = min;
+      min = max;
+      max = tmp;
+    }
+
+    const chance = Number(source.chance);
+    const normalizedChance = Number.isFinite(chance)
+      ? Math.max(0, Math.min(1, chance))
+      : defaults.chance;
+
+    const hold = Number(source.hold);
+    const normalizedHold = Number.isFinite(hold) ? hold : defaults.hold;
+    const holdSteps = clampInt(normalizedHold, 1, 128);
+
+    let amount = Number(source.amount);
+    if (!Number.isFinite(amount)) {
+      amount = Math.max(Math.abs(min), Math.abs(max), defaults.amount);
+    } else {
+      amount = Math.max(0, Math.abs(amount));
+    }
+    if (!Number.isFinite(amount) || amount <= 0) {
+      amount = Math.max(Math.abs(min), Math.abs(max), defaults.amount);
+    }
+
+    const target = typeof source.target === 'string' ? source.target : defaults.target;
+
+    return {
+      type,
+      config: {
+        target,
+        min,
+        max,
+        amount,
+        chance: normalizedChance,
+        hold: holdSteps,
+      },
+    };
+  }
+
+  return cloneFxDefaults();
+}
+
+export function createStepFx(type = STEP_FX_TYPES.NONE) {
+  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
+    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
+    return normalizeStepFx({
+      type,
+      config: { ...defaults },
+    });
+  }
+  return cloneFxDefaults();
+}
+
 export function getStepVelocity(step, fallback = 0) {
   if (!step || typeof step !== 'object') return fallback;
   const params = step.params;
@@ -39,6 +155,7 @@ export function normalizeStep(step) {
   const normalized = {
     on: !!src.on,
     params: { ...(src.params && typeof src.params === 'object' ? src.params : {}) },
+    fx: normalizeStepFx(src.fx),
     vel: 0,
   };
   const fallback = normalized.on ? 1 : 0;


### PR DESCRIPTION
## Summary
- add step FX definitions/defaults and persist them through normalization and pattern serialization
- build the step effects UI to configure Sample & Hold per-step parameters
- evaluate Sample & Hold offsets during transport and merge them with existing parameter mods

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc3874a004832d9966e1d687ac1c65