### PR TITLE
Allow modulators to affect effect parameters

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -65,6 +65,14 @@ const FALLBACK_TARGETS = Object.freeze(
   Object.values(TARGETS_BY_ENGINE).flat()
 );
 
+const FX_TARGET_OPTIONS = [
+  { value: 'fx.sampleHold.min', label: 'FX • S&H Min' },
+  { value: 'fx.sampleHold.max', label: 'FX • S&H Max' },
+  { value: 'fx.sampleHold.amount', label: 'FX • S&H Amount' },
+  { value: 'fx.sampleHold.chance', label: 'FX • S&H Chance' },
+  { value: 'fx.sampleHold.hold', label: 'FX • S&H Hold' },
+];
+
 function getTargetOptionsForTrack(track) {
   if (track?.engine && TARGETS_BY_ENGINE[track.engine]) {
     return TARGETS_BY_ENGINE[track.engine];
@@ -1237,7 +1245,11 @@ export function renderModulationRack(rootEl, track) {
     row.appendChild(createModCell('Depth', depthControl.wrap));
 
     const targetSelect = document.createElement('select');
-    const baseOptions = [...getTargetOptionsForTrack(track)];
+    const optionSource = getTargetOptionsForTrack(track);
+    const baseOptions = [
+      ...(Array.isArray(optionSource) ? optionSource : []),
+      ...FX_TARGET_OPTIONS,
+    ];
     const currentTarget = Array.isArray(mod.target)
       ? mod.target.join('.')
       : (mod.target || '');


### PR DESCRIPTION
## Summary
- allow applyMods to build separate parameter and effect offset maps so modulators can target FX controls
- apply Sample & Hold overrides during playback without mutating stored step FX configuration
- list Sample & Hold effect parameters in the modulation target dropdown for easy selection

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d2fdfd0b8c832d856b799e9e9dd6d0