### PR TITLE
Extract step FX logic into dedicated module

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,8 +3,8 @@ import { ctx, startTransport, stopTransport } from './core.js';
 import {
   createTrack, triggerEngine, applyMixer, resizeTrackSteps,
   notesStartingAt, normalizeStep, setStepVelocity, getStepVelocity,
-  STEP_FX_TYPES, normalizeStepFx,
 } from './tracks.js';
+import { STEP_FX_TYPES, normalizeStepFx } from './stepfx.js';
 import { evaluateSampleHoldFx } from './samplenhold.js';
 import { applyMods } from './mods.js';
 import { createGrid } from './sequencer.js';

--- a/samplenhold.js
+++ b/samplenhold.js
@@ -1,5 +1,5 @@
 // samplenhold.js
-import { STEP_FX_TYPES, normalizeStepFx } from './tracks.js';
+import { STEP_FX_TYPES, normalizeStepFx } from './stepfx.js';
 
 export function buildOffsetFromPath(pathParts, value) {
   if (!Array.isArray(pathParts) || !pathParts.length) return null;

--- a/stepfx.js
+++ b/stepfx.js
@@ -1,0 +1,117 @@
+import { clampInt } from './core.js';
+
+export const STEP_FX_TYPES = Object.freeze({
+  NONE: '',
+  SAMPLE_HOLD: 'sampleHold',
+});
+
+export const STEP_FX_DEFAULTS = Object.freeze({
+  [STEP_FX_TYPES.SAMPLE_HOLD]: Object.freeze({
+    target: 'velocity',
+    min: -0.25,
+    max: 0.25,
+    amount: 0.25,
+    chance: 1,
+    hold: 1,
+  }),
+});
+
+function cloneFxDefaults(type = STEP_FX_TYPES.NONE) {
+  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
+    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
+    return {
+      type,
+      config: {
+        target: defaults.target,
+        min: defaults.min,
+        max: defaults.max,
+        amount: defaults.amount,
+        chance: defaults.chance,
+        hold: defaults.hold,
+      },
+    };
+  }
+  return { type: STEP_FX_TYPES.NONE, config: {} };
+}
+
+export function normalizeStepFx(definition) {
+  if (!definition || typeof definition !== 'object') {
+    return cloneFxDefaults();
+  }
+
+  const type = typeof definition.type === 'string' ? definition.type.trim() : '';
+  if (!type || !(type in STEP_FX_DEFAULTS)) {
+    return cloneFxDefaults();
+  }
+
+  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
+    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
+    const source = definition.config && typeof definition.config === 'object'
+      ? definition.config
+      : {};
+
+    let min = Number(source.min);
+    if (!Number.isFinite(min)) {
+      const amount = Number(source.amount);
+      min = Number.isFinite(amount) ? -Math.abs(amount) : defaults.min;
+    }
+
+    let max = Number(source.max);
+    if (!Number.isFinite(max)) {
+      const amount = Number(source.amount);
+      max = Number.isFinite(amount) ? Math.abs(amount) : defaults.max;
+    }
+
+    if (min > max) {
+      const tmp = min;
+      min = max;
+      max = tmp;
+    }
+
+    const chance = Number(source.chance);
+    const normalizedChance = Number.isFinite(chance)
+      ? Math.max(0, Math.min(1, chance))
+      : defaults.chance;
+
+    const hold = Number(source.hold);
+    const normalizedHold = Number.isFinite(hold) ? hold : defaults.hold;
+    const holdSteps = clampInt(normalizedHold, 1, 128);
+
+    let amount = Number(source.amount);
+    if (!Number.isFinite(amount)) {
+      amount = Math.max(Math.abs(min), Math.abs(max), defaults.amount);
+    } else {
+      amount = Math.max(0, Math.abs(amount));
+    }
+    if (!Number.isFinite(amount) || amount <= 0) {
+      amount = Math.max(Math.abs(min), Math.abs(max), defaults.amount);
+    }
+
+    const target = typeof source.target === 'string' ? source.target : defaults.target;
+
+    return {
+      type,
+      config: {
+        target,
+        min,
+        max,
+        amount,
+        chance: normalizedChance,
+        hold: holdSteps,
+      },
+    };
+  }
+
+  return cloneFxDefaults();
+}
+
+export function createStepFx(type = STEP_FX_TYPES.NONE) {
+  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
+    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
+    return normalizeStepFx({
+      type,
+      config: { ...defaults },
+    });
+  }
+  return cloneFxDefaults();
+}

--- a/tracks.js
+++ b/tracks.js
@@ -1,5 +1,8 @@
 import { ctx, master, clampInt } from './core.js';
 import { synthBlip, kick808, snare808, hat808, clap909, samplerPlay } from './engines.js';
+import { normalizeStepFx } from './stepfx.js';
+
+export { STEP_FX_TYPES, STEP_FX_DEFAULTS, createStepFx, normalizeStepFx } from './stepfx.js';
 
 export const STEP_CHOICES = [4, 8, 12, 16, 24, 32];
 
@@ -13,122 +16,6 @@ export const defaults = {
 };
 
 const clone = o => JSON.parse(JSON.stringify(o));
-
-export const STEP_FX_TYPES = Object.freeze({
-  NONE: '',
-  SAMPLE_HOLD: 'sampleHold',
-});
-
-export const STEP_FX_DEFAULTS = Object.freeze({
-  [STEP_FX_TYPES.SAMPLE_HOLD]: Object.freeze({
-    target: 'velocity',
-    min: -0.25,
-    max: 0.25,
-    amount: 0.25,
-    chance: 1,
-    hold: 1,
-  }),
-});
-
-function cloneFxDefaults(type = STEP_FX_TYPES.NONE) {
-  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
-    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
-    return {
-      type,
-      config: {
-        target: defaults.target,
-        min: defaults.min,
-        max: defaults.max,
-        amount: defaults.amount,
-        chance: defaults.chance,
-        hold: defaults.hold,
-      },
-    };
-  }
-  return { type: STEP_FX_TYPES.NONE, config: {} };
-}
-
-export function normalizeStepFx(definition) {
-  if (!definition || typeof definition !== 'object') {
-    return cloneFxDefaults();
-  }
-
-  const type = typeof definition.type === 'string' ? definition.type.trim() : '';
-  if (!type || !(type in STEP_FX_DEFAULTS)) {
-    return cloneFxDefaults();
-  }
-
-  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
-    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
-    const source = definition.config && typeof definition.config === 'object'
-      ? definition.config
-      : {};
-
-    let min = Number(source.min);
-    if (!Number.isFinite(min)) {
-      const amount = Number(source.amount);
-      min = Number.isFinite(amount) ? -Math.abs(amount) : defaults.min;
-    }
-
-    let max = Number(source.max);
-    if (!Number.isFinite(max)) {
-      const amount = Number(source.amount);
-      max = Number.isFinite(amount) ? Math.abs(amount) : defaults.max;
-    }
-
-    if (min > max) {
-      const tmp = min;
-      min = max;
-      max = tmp;
-    }
-
-    const chance = Number(source.chance);
-    const normalizedChance = Number.isFinite(chance)
-      ? Math.max(0, Math.min(1, chance))
-      : defaults.chance;
-
-    const hold = Number(source.hold);
-    const normalizedHold = Number.isFinite(hold) ? hold : defaults.hold;
-    const holdSteps = clampInt(normalizedHold, 1, 128);
-
-    let amount = Number(source.amount);
-    if (!Number.isFinite(amount)) {
-      amount = Math.max(Math.abs(min), Math.abs(max), defaults.amount);
-    } else {
-      amount = Math.max(0, Math.abs(amount));
-    }
-    if (!Number.isFinite(amount) || amount <= 0) {
-      amount = Math.max(Math.abs(min), Math.abs(max), defaults.amount);
-    }
-
-    const target = typeof source.target === 'string' ? source.target : defaults.target;
-
-    return {
-      type,
-      config: {
-        target,
-        min,
-        max,
-        amount,
-        chance: normalizedChance,
-        hold: holdSteps,
-      },
-    };
-  }
-
-  return cloneFxDefaults();
-}
-
-export function createStepFx(type = STEP_FX_TYPES.NONE) {
-  if (type === STEP_FX_TYPES.SAMPLE_HOLD) {
-    const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.SAMPLE_HOLD];
-    return normalizeStepFx({
-      type,
-      config: { ...defaults },
-    });
-  }
-  return cloneFxDefaults();
-}
 
 export function getStepVelocity(step, fallback = 0) {
   if (!step || typeof step !== 'object') return fallback;

--- a/ui.js
+++ b/ui.js
@@ -1,15 +1,17 @@
 // ui.js
 import {
   STEP_CHOICES,
-  STEP_FX_TYPES,
-  STEP_FX_DEFAULTS,
-  createStepFx,
-  normalizeStepFx,
   createModulator,
   removeModulator,
   getStepVelocity,
   setStepVelocity,
 } from './tracks.js';
+import {
+  STEP_FX_TYPES,
+  STEP_FX_DEFAULTS,
+  createStepFx,
+  normalizeStepFx,
+} from './stepfx.js';
 
 const MOD_SOURCES = [
   { value: 'lfo', label: 'LFO' },


### PR DESCRIPTION
## Summary
- move all step FX constants and helpers into a dedicated `stepfx.js` module
- update the track utilities to rely on and re-export the new shared helpers
- point the main loop, UI, and sample & hold logic at the new module

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3092a75ec832dbcf1ba06c9b59324