### PR TITLE
Simplify sample & hold step FX to velocity offsets

### DIFF
--- a/main.js
+++ b/main.js
@@ -809,15 +809,7 @@ playBtn.onclick = async () => {
           if (st?.on) {
             const fxResult = evaluateStepFx(t, st, t.pos, effectOffsets);
             let vel = getStepVelocity(st, 1);
-            if (fxResult) {
-              const offsets = fxResult.paramOffsets
-                || (fxResult && !('paramOffsets' in fxResult) && !('velocityOffset' in fxResult)
-                  ? fxResult
-                  : null);
-              if (offsets) {
-                const restore = mergeParamOffsets(t.params, offsets);
-                if (typeof restore === 'function') restoreStack.push(restore);
-              }
+            if (fxResult && typeof fxResult === 'object') {
               if (Number.isFinite(fxResult.velocityOffset)) {
                 vel += fxResult.velocityOffset;
               }

--- a/stepfx.js
+++ b/stepfx.js
@@ -7,7 +7,6 @@ export const STEP_FX_TYPES = Object.freeze({
 
 export const STEP_FX_DEFAULTS = Object.freeze({
   [STEP_FX_TYPES.SAMPLE_HOLD]: Object.freeze({
-    target: 'velocity',
     min: -0.25,
     max: 0.25,
     amount: 0.25,
@@ -22,7 +21,6 @@ function cloneFxDefaults(type = STEP_FX_TYPES.NONE) {
     return {
       type,
       config: {
-        target: defaults.target,
         min: defaults.min,
         max: defaults.max,
         amount: defaults.amount,
@@ -87,12 +85,9 @@ export function normalizeStepFx(definition) {
       amount = Math.max(Math.abs(min), Math.abs(max), defaults.amount);
     }
 
-    const target = typeof source.target === 'string' ? source.target : defaults.target;
-
     return {
       type,
       config: {
-        target,
         min,
         max,
         amount,


### PR DESCRIPTION
## Summary
- remove the sample & hold target property so normalization and defaults only track playback parameters
- evaluate sample & hold as a velocity-only effect and drop the param offset helper path
- refresh the step FX panel to remove the target selector and relabel the remaining velocity controls

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d30bf2e95c832d8832f21a02fa3426