### PR TITLE
Add loop chain toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,10 @@
         <button id="chainClear" class="ghost">Clear Chain</button>
         <button id="chainPrev">◀ Prev</button>
         <button id="chainNext">Next ▶</button>
+        <label class="ctrl">
+          <input id="loopChain" type="checkbox">
+          Loop Chain
+        </label>
         <span id="chainStatus" class="hint"></span>
       </div>
     </section>

--- a/main.js
+++ b/main.js
@@ -24,13 +24,14 @@ const addPatternBtn    = document.getElementById('addPattern');
 const dupPatternBtn    = document.getElementById('dupPattern');
 const patLenInput      = document.getElementById('patLen');
 
-const chainAddBtn      = document.getElementById('chainAdd');
-const chainClearBtn    = document.getElementById('chainClear');
-const chainPrevBtn     = document.getElementById('chainPrev');
-const chainNextBtn     = document.getElementById('chainNext');
+const chainAddBtn       = document.getElementById('chainAdd');
+const chainClearBtn     = document.getElementById('chainClear');
+const chainPrevBtn      = document.getElementById('chainPrev');
+const chainNextBtn      = document.getElementById('chainNext');
 const followChainToggle = document.getElementById('followChain');
-const chainView        = document.getElementById('chainView');
-const chainStatus      = document.getElementById('chainStatus');
+const loopChainToggle   = document.getElementById('loopChain');
+const chainView         = document.getElementById('chainView');
+const chainStatus       = document.getElementById('chainStatus');
 
 const togglePiano  = document.getElementById('togglePiano');
 const playBtn      = document.getElementById('play');
@@ -48,6 +49,7 @@ const song = {
   chain: [{ pattern: 0, repeats: 1 }],
   chainPos: 0,
   followChain: false,
+  loopChain: false,
   chainRepeatsLeft: 0
 };
 
@@ -545,6 +547,7 @@ function renderChain() {
     if (chainNextBtn) chainNextBtn.disabled = true;
     if (chainClearBtn) chainClearBtn.disabled = true;
     if (followChainToggle) followChainToggle.checked = !!song.followChain;
+    if (loopChainToggle) loopChainToggle.checked = !!song.loopChain;
     return;
   }
 
@@ -580,13 +583,15 @@ function renderChain() {
 
   chainView.appendChild(frag);
 
-  if (chainPrevBtn) chainPrevBtn.disabled = song.chainPos <= 0;
-  if (chainNextBtn) chainNextBtn.disabled = song.chainPos >= total - 1;
+  if (chainPrevBtn) chainPrevBtn.disabled = !song.loopChain && song.chainPos <= 0;
+  if (chainNextBtn) chainNextBtn.disabled = !song.loopChain && song.chainPos >= total - 1;
   if (chainClearBtn) chainClearBtn.disabled = false;
   if (followChainToggle) followChainToggle.checked = !!song.followChain;
+  if (loopChainToggle) loopChainToggle.checked = !!song.loopChain;
 
   const statusParts = [`Slot ${song.chainPos + 1}/${total}`];
   if (song.followChain) statusParts.push('Auto');
+  if (song.loopChain) statusParts.push('Loop');
   if (chainStatus) chainStatus.textContent = statusParts.join(' • ');
 }
 
@@ -606,7 +611,14 @@ function gotoChainSlot(slotIndex) {
     return;
   }
 
-  const clamped = Math.max(0, Math.min(song.chain.length - 1, slotIndex|0));
+  const total = song.chain.length;
+  let targetIndex = slotIndex | 0;
+  if (song.loopChain && total > 0) {
+    targetIndex %= total;
+    if (targetIndex < 0) targetIndex += total;
+  }
+
+  const clamped = Math.max(0, Math.min(total - 1, targetIndex));
   song.chainPos = clamped;
 
   const slot = song.chain[clamped];
@@ -725,6 +737,11 @@ if (followChainToggle) followChainToggle.onchange = () => {
   } else {
     song.chainRepeatsLeft = 0;
   }
+  renderChain();
+};
+
+if (loopChainToggle) loopChainToggle.onchange = () => {
+  song.loopChain = loopChainToggle.checked;
   renderChain();
 };
 


### PR DESCRIPTION
## Summary
- add a Loop Chain checkbox to the chain controls
- store the loop state and expose it through the UI and status text
- allow chain navigation and auto-follow to wrap around when looping is enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9eb5a750832da99a2971e51327a1