### PR TITLE
Add track-level compression effect and controls

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import { ctx, startTransport, stopTransport } from './core.js';
 import {
   createTrack, triggerEngine, applyMixer, resizeTrackSteps,
   notesStartingAt, normalizeStep, setStepVelocity, getStepVelocity,
+  syncTrackEffects,
 } from './tracks.js';
 import { STEP_FX_TYPES, STEP_FX_DEFAULTS, normalizeStepFx } from './stepfx.js';
 import { applyMods } from './mods.js';
@@ -126,6 +127,8 @@ function normalizeTrack(t) {
       if (mod.enabled === undefined) mod.enabled = true;
     }
   }
+
+  syncTrackEffects(t);
 
   if (!Array.isArray(t.chain) || !t.chain.length) {
     t.chain = [{ pattern: song.current ?? 0, repeats: 1 }];
@@ -391,6 +394,9 @@ function renderParamsPanel(){
     onStepFxChange: () => {
       renderCurrentEditor();
     },
+    onTrackFxChange: () => {
+      syncTrackEffects(track);
+    },
   });
   const inlineStep = paramsEl?._inlineStepEditor;
   if (inlineStep && track && Array.isArray(track.steps)) {
@@ -404,6 +410,10 @@ function renderParamsPanel(){
   const stepFx = paramsEl?._stepFxEditor;
   if (stepFx && typeof stepFx.refresh === 'function') {
     stepFx.refresh();
+  }
+  const trackFx = paramsEl?._trackFxEditor;
+  if (trackFx && typeof trackFx.refresh === 'function') {
+    trackFx.refresh();
   }
   setTrackSelectedStep(track, getTrackSelectedStep(track), { force: true });
 }

--- a/patterns.js
+++ b/patterns.js
@@ -5,6 +5,8 @@ import {
   normalizeStep,
   getStepVelocity,
   setStepVelocity,
+  normalizeTrackEffects,
+  syncTrackEffects,
 } from './tracks.js';
 
 // structuredClone is not universally supported in all browsers, so fall back to
@@ -40,6 +42,7 @@ export function serializePattern(name, tracks, patternLen16 = 16) {
       })),
       gain: t.gain, pan: t.pan, mute: t.mute, solo: t.solo,
       params: clone(t.params),
+      effects: clone(t.effects || {}),
       sampleName: t.sample?.name || '',
       mods: Array.isArray(t.mods) ? t.mods
         .filter(mod => mod && typeof mod === 'object')
@@ -79,6 +82,8 @@ export function instantiatePattern(pat, sampleCache = {}) {
     })) : [];
     t.gain = td.gain; t.pan = td.pan; t.mute = td.mute; t.solo = td.solo;
     t.params = clone(td.params);
+    t.effects = normalizeTrackEffects(td.effects);
+    syncTrackEffects(t);
     if (Array.isArray(td.mods)) {
       for (const mod of td.mods) {
         if (!mod || typeof mod !== 'object') continue;

--- a/style.css
+++ b/style.css
@@ -64,6 +64,15 @@ h3 { margin:0 0 8px; font-weight:600; }
 .step-fx-readout { font-size:12px; color:var(--muted); font-variant-numeric: tabular-nums; }
 .step-fx-hint { flex:1 1 100%; font-size:11px; color:var(--muted); }
 
+.track-fx-controls { display:flex; flex-direction:column; gap:12px; width:100%; }
+.track-fx-toggle { display:flex; align-items:center; gap:8px; font-size:13px; color:var(--muted); }
+.track-fx-toggle input { width:16px; height:16px; }
+.track-fx-grid { display:flex; flex-direction:column; gap:10px; width:100%; }
+.track-fx-grid.track-fx-disabled { opacity:0.55; }
+.track-fx-row { display:flex; flex-direction:column; gap:6px; }
+.track-fx-label { font-size:12px; color:var(--muted); }
+.track-fx-hint { font-size:11px; color:var(--muted); }
+
 .sampler-advanced {
   display:none;
   margin:8px 0 0;


### PR DESCRIPTION
## Summary
- add track-level effect infrastructure with a compression node and hook tracks into the new FX chain
- persist track effects with patterns and expose compression controls in the track parameter UI

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe83d55f0832d80c1edcd689c4615