### PR TITLE
Update artifact upload action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             -o dist/kj_dsp.js
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kj_dsp
           path: dist


### PR DESCRIPTION
## Summary
- bump upload-artifact action in build workflow to the latest major version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0df2b73c832d887ffb44b1dde17e