### PR TITLE
Serve DSP bundle from web/dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
             -s ALLOW_MEMORY_GROWTH=1 \
             -s EXPORTED_FUNCTIONS='[_malloc,_free,_kj_set_sample_rate,_kj_calculate_synth_samples,_kj_calculate_kick_samples,_kj_calculate_snare_samples,_kj_calculate_hat_samples,_kj_calculate_clap_samples,_kj_generate_synth,_kj_generate_kick,_kj_generate_snare,_kj_generate_hat,_kj_generate_clap]' \
             -o dist/kj_dsp.js
+          mkdir -p web/dist
+          cp dist/kj_dsp.js dist/kj_dsp.wasm web/dist/
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ KJ: web groovebox
 - `web/` contains the browser UI (HTML, CSS, JS).
 - `src/` contains the C++ DSP implementation that compiles to WebAssembly.
 - `dist/` is where the WebAssembly build outputs (`kj_dsp.wasm`, `kj_dsp.js`) will be written.
+- `web/dist/` is where the UI serves the compiled assets from; copy the build outputs here before running the browser app.
 
 ## Building the DSP module
 
@@ -24,14 +25,19 @@ emcc src/*.cpp \
   -o dist/kj_dsp.js
 ```
 
-The command generates `dist/kj_dsp.js` and `dist/kj_dsp.wasm`, which are then loaded by the UI at runtime.
+The command generates `dist/kj_dsp.js` and `dist/kj_dsp.wasm`. Copy both files into `web/dist/` so the UI can load them:
+
+```
+mkdir -p web/dist
+cp dist/kj_dsp.js dist/kj_dsp.wasm web/dist/
+```
 
 ## Running the UI
 
-Serve the `web/` directory with any static file server. For example:
+Serve the `web/` directory (which should now contain `web/dist/kj_dsp.js` and `web/dist/kj_dsp.wasm`) with any static file server. For example:
 
 ```
 npx serve web
 ```
 
-The UI expects the compiled WebAssembly files to be available at `dist/kj_dsp.js` and `dist/kj_dsp.wasm` relative to the project root.
+The UI expects the compiled WebAssembly files to be available at `web/dist/kj_dsp.js` and `web/dist/kj_dsp.wasm` relative to the `web/` directory root.

--- a/web/dsp.js
+++ b/web/dsp.js
@@ -5,9 +5,9 @@ let currentSampleRate = 0;
 async function loadModule() {
   let imported;
   try {
-    imported = await import('../dist/kj_dsp.js');
+    imported = await import('./dist/kj_dsp.js');
   } catch (err) {
-    throw new Error('Unable to load dist/kj_dsp.js. Build the WebAssembly module before running the UI.');
+    throw new Error('Unable to load ./dist/kj_dsp.js. Build the WebAssembly module and copy it into web/dist/ before running the UI.');
   }
   const factory = imported?.default;
   if (typeof factory !== 'function') {


### PR DESCRIPTION
## Summary
- load the DSP module from the web/dist directory and improve the error guidance when it is missing
- copy the generated wasm/js artifacts into web/dist as part of the CI build
- document the new artifact location and local serving steps in the README

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dc12636468832da53f86feff2150ae