### PR TITLE
Enable realtime track pitch changes

### DIFF
--- a/web/engine-utils.js
+++ b/web/engine-utils.js
@@ -30,9 +30,9 @@ export function playSamples(samples, dest, when, durationSec, options = {}) {
   source.connect(gain).connect(target);
   const startTime = Number.isFinite(when) ? when : ctx.currentTime;
   const semis = Number(options?.pitchSemis);
-  if (Number.isFinite(semis) && semis !== 0) {
-    const rate = Math.pow(2, semis / 12);
-    source.playbackRate.setValueAtTime(rate, startTime);
+  const playbackRate = Number.isFinite(semis) ? Math.pow(2, semis / 12) : 1;
+  if (playbackRate !== 1) {
+    source.playbackRate.setValueAtTime(playbackRate, startTime);
   }
   const playDuration = Number.isFinite(durationSec) && durationSec > 0
     ? Math.min(buffer.duration, durationSec)
@@ -48,5 +48,5 @@ export function playSamples(samples, dest, when, durationSec, options = {}) {
     try { source.disconnect(); } catch {}
     try { gain.disconnect(); } catch {}
   };
-  return { source, gain };
+  return { source, gain, playbackRate };
 }

--- a/web/engines.js
+++ b/web/engines.js
@@ -19,7 +19,7 @@ export { samplerPlay } from './sampler-engine.js';
 export function kick808(p, dest, vel = 1, semis = 0, when, durationSec) {
   if (!isDspReady()) return;
   const samples = renderKickSamples(p, vel);
-  playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
+  return playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
 }
 
 /* ===========================
@@ -28,7 +28,7 @@ export function kick808(p, dest, vel = 1, semis = 0, when, durationSec) {
 export function snare808(p, dest, vel = 1, semis = 0, when, durationSec) {
   if (!isDspReady()) return;
   const samples = renderSnareSamples(p, vel);
-  playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
+  return playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
 }
 
 /* ===========================
@@ -37,7 +37,7 @@ export function snare808(p, dest, vel = 1, semis = 0, when, durationSec) {
 export function hat808(p, dest, vel = 1, semis = 0, when, durationSec) {
   if (!isDspReady()) return;
   const samples = renderHatSamples(p, vel);
-  playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
+  return playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
 }
 
 /* ===========================
@@ -46,5 +46,5 @@ export function hat808(p, dest, vel = 1, semis = 0, when, durationSec) {
 export function clap909(p, dest, vel = 1, semis = 0, when, durationSec) {
   if (!isDspReady()) return;
   const samples = renderClapSamples(p, vel);
-  playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
+  return playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
 }

--- a/web/juno60-engine.js
+++ b/web/juno60-engine.js
@@ -4,5 +4,5 @@ import { playSamples } from './engine-utils.js';
 export function juno60Blip(p, dest, vel = 1, semis = 0, when, durationSec) {
   if (!isDspReady()) return;
   const samples = renderJunoSamples(p, vel, 0);
-  playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
+  return playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
 }

--- a/web/main.js
+++ b/web/main.js
@@ -3,7 +3,7 @@ import { ctx, master, startTransport, stopTransport, dspReady, ensureAudioReady,
 import {
   createTrack, triggerEngine, applyMixer, resizeTrackSteps,
   notesStartingAt, normalizeStep, setStepVelocity, getStepVelocity,
-  syncTrackEffects, defaults, ARP_DEFAULTS,
+  syncTrackEffects, updateTrackPitchVoices, defaults, ARP_DEFAULTS,
 } from './tracks.js';
 import { STEP_FX_TYPES, STEP_FX_DEFAULTS, normalizeStepFx } from './stepfx.js';
 import { applyMods } from './mods.js';
@@ -3216,6 +3216,7 @@ playBtn.onclick = async () => {
       const trackPitchSemisOffset = pitchFxEnabled
         ? (pitchFxSemisOffset + (pitchFxOctaveOffset * 12))
         : 0;
+      updateTrackPitchVoices?.(t, trackPitchSemisOffset, scheduledTime);
 
       try {
         if (t.type === 'cvl') {

--- a/web/noise-engine.js
+++ b/web/noise-engine.js
@@ -4,5 +4,5 @@ import { playSamples } from './engine-utils.js';
 export function noiseSynth(p, dest, vel = 1, semis = 0, when, durationSec) {
   if (!isDspReady()) return;
   const samples = renderNoiseSamples(p, vel, 0);
-  playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
+  return playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
 }

--- a/web/sampler-engine.js
+++ b/web/sampler-engine.js
@@ -99,4 +99,9 @@ export function samplerPlay(p, dest, vel = 1, sample, semis = 0, when, durationS
   applyDeclickEnvelope(vca, (p.gain ?? 1) * vel, startTime, duration);
   src.start(startTime, startSec, duration);
   src.stop(startTime + duration + 0.005);
+  src.onended = () => {
+    try { src.disconnect(); } catch {}
+    try { vca.disconnect(); } catch {}
+  };
+  return { source: src, gain: vca, playbackRate: rate };
 }

--- a/web/synth-engine.js
+++ b/web/synth-engine.js
@@ -4,5 +4,5 @@ import { playSamples } from './engine-utils.js';
 export function synthBlip(p, dest, vel = 1, semis = 0, when, durationSec) {
   if (!isDspReady()) return;
   const samples = renderSynthSamples(p, vel, 0);
-  playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
+  return playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
 }

--- a/web/tb303-engine.js
+++ b/web/tb303-engine.js
@@ -16,5 +16,5 @@ export function tb303Blip(p, dest, vel = 1, semis = 0, when, durationSec) {
     morph: p?.morph ?? 0,
   };
   const samples = renderSynthSamples(mapped, vel * (1 + accent * 0.5), 0);
-  playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
+  return playSamples(samples, dest, when, durationSec, { pitchSemis: semis });
 }

--- a/web/tracks.js
+++ b/web/tracks.js
@@ -380,6 +380,66 @@ export function normalizeTrackEffects(effects = {}) {
   };
 }
 
+
+function resolveTrackPitchSemis(track, extraOffset = 0) {
+  const pitchFxState = track?.effects?.pitch && typeof track.effects.pitch === 'object' ? track.effects.pitch : null;
+  if (pitchFxState?.enabled !== true) return 0;
+  const pitchSemis = Number.isFinite(Number(pitchFxState.pitch)) ? Number(pitchFxState.pitch) : 0;
+  const pitchOctave = Number.isFinite(Number(pitchFxState.octave)) ? Math.trunc(Number(pitchFxState.octave)) : 0;
+  const pitchOffset = Number.isFinite(Number(extraOffset)) ? Number(extraOffset) : 0;
+  return pitchSemis + (pitchOctave * 12) + pitchOffset;
+}
+
+function getVoiceSource(voice) {
+  return voice?.source || voice?.src || null;
+}
+
+function registerTrackPitchVoice(track, voice, appliedTrackPitchSemis = 0) {
+  const source = getVoiceSource(voice);
+  if (!track || !source?.playbackRate) return voice;
+  if (!Array.isArray(track._pitchVoices)) track._pitchVoices = [];
+  const voiceRate = Number(voice?.playbackRate);
+  const paramRate = Number(source.playbackRate.value);
+  const startRate = Number.isFinite(voiceRate) && voiceRate > 0
+    ? voiceRate
+    : paramRate;
+  const basePlaybackRate = Number.isFinite(startRate) && startRate > 0
+    ? startRate / Math.pow(2, appliedTrackPitchSemis / 12)
+    : Math.pow(2, -appliedTrackPitchSemis / 12);
+  const entry = { source, basePlaybackRate };
+  track._pitchVoices.push(entry);
+
+  const previousOnEnded = source.onended;
+  source.onended = (...args) => {
+    const voices = Array.isArray(track._pitchVoices) ? track._pitchVoices : [];
+    const idx = voices.indexOf(entry);
+    if (idx >= 0) voices.splice(idx, 1);
+    if (typeof previousOnEnded === 'function') previousOnEnded.apply(source, args);
+  };
+  return voice;
+}
+
+export function updateTrackPitchVoices(track, extraOffset = 0, when = ctx.currentTime) {
+  if (!track || !Array.isArray(track._pitchVoices) || !track._pitchVoices.length) return;
+  const pitchSemis = resolveTrackPitchSemis(track, extraOffset);
+  const rateMultiplier = Math.pow(2, pitchSemis / 12);
+  const now = Number.isFinite(when) ? Math.max(ctx.currentTime, when) : ctx.currentTime;
+  track._pitchVoices = track._pitchVoices.filter((entry) => {
+    const source = entry?.source;
+    const param = source?.playbackRate;
+    const baseRate = Number(entry?.basePlaybackRate);
+    if (!param || !Number.isFinite(baseRate) || baseRate <= 0) return false;
+    const nextRate = Math.max(0.0001, baseRate * rateMultiplier);
+    try {
+      param.cancelScheduledValues(now);
+      param.setTargetAtTime(nextRate, now, 0.01);
+    } catch {
+      try { param.setValueAtTime(nextRate, now); } catch { return false; }
+    }
+    return true;
+  });
+}
+
 export function syncTrackEffects(track) {
   if (!track) return null;
   const normalized = normalizeTrackEffects(track.effects);
@@ -404,6 +464,7 @@ export function syncTrackEffects(track) {
     try { eqNodes.high.gain.setValueAtTime(eq3.highGain, now); } catch {}
   }
   rebuildTrackFxChain(track);
+  updateTrackPitchVoices(track);
   return normalized;
 }
 
@@ -478,31 +539,30 @@ export function resizeTrackSteps(track, newLen){
 
 export function triggerEngine(track, vel=1, semis=0, when, gateSec, options){
   const dest = track?.inputNode || track?.gainNode;
-  const pitchFxState = track?.effects?.pitch && typeof track.effects.pitch === 'object' ? track.effects.pitch : null;
-  const pitchFxEnabled = pitchFxState?.enabled === true;
-  const pitchSemis = Number.isFinite(Number(pitchFxState?.pitch)) ? Number(pitchFxState.pitch) : 0;
-  const pitchOctave = Number.isFinite(Number(pitchFxState?.octave)) ? Math.trunc(Number(pitchFxState.octave)) : 0;
   const pitchOffset = Number.isFinite(Number(options?.trackPitchSemisOffset)) ? Number(options.trackPitchSemisOffset) : 0;
-  const resolvedSemis = (Number.isFinite(Number(semis)) ? Number(semis) : 0)
-    + (pitchFxEnabled ? (pitchSemis + (pitchOctave * 12) + pitchOffset) : 0);
+  const trackPitchSemis = resolveTrackPitchSemis(track, pitchOffset);
+  const resolvedSemis = (Number.isFinite(Number(semis)) ? Number(semis) : 0) + trackPitchSemis;
+  let voice = null;
   if (isBeepboxSynthEngine(track.engine)) {
     const sourceParams = track.params[track.engine] && typeof track.params[track.engine] === 'object'
       ? track.params[track.engine]
       : track.params.synth;
     const beepboxParams = getBeepboxSynthParams(track.engine, sourceParams);
-    return synthBlip(beepboxParams, dest, vel, resolvedSemis, when, gateSec);
+    voice = synthBlip(beepboxParams, dest, vel, resolvedSemis, when, gateSec);
+    return registerTrackPitchVoice(track, voice, trackPitchSemis);
   }
   switch(track.engine){
-    case 'synth':    return synthBlip(track.params.synth,    dest, vel, resolvedSemis, when, gateSec);
-    case 'juno60':   return juno60Blip(track.params.juno60,   dest, vel, resolvedSemis, when, gateSec);
-    case 'tb303':    return tb303Blip(track.params.tb303,    dest, vel, resolvedSemis, when, gateSec);
-    case 'noise':    return noiseSynth(track.params.noise,   dest, vel, resolvedSemis, when, gateSec);
-    case 'kick808':  return kick808(track.params.kick808,    dest, vel, resolvedSemis, when, gateSec);
-    case 'snare808': return snare808(track.params.snare808,  dest, vel, resolvedSemis, when, gateSec);
-    case 'hat808':   return hat808(track.params.hat808,      dest, vel, resolvedSemis, when, gateSec);
-    case 'clap909':  return clap909(track.params.clap909,    dest, vel, resolvedSemis, when, gateSec);
-    case 'sampler':  return samplerPlay(track.params.sampler,dest, vel, track.sample, resolvedSemis, when, gateSec, options);
+    case 'synth':    voice = synthBlip(track.params.synth,    dest, vel, resolvedSemis, when, gateSec); break;
+    case 'juno60':   voice = juno60Blip(track.params.juno60,   dest, vel, resolvedSemis, when, gateSec); break;
+    case 'tb303':    voice = tb303Blip(track.params.tb303,    dest, vel, resolvedSemis, when, gateSec); break;
+    case 'noise':    voice = noiseSynth(track.params.noise,   dest, vel, resolvedSemis, when, gateSec); break;
+    case 'kick808':  voice = kick808(track.params.kick808,    dest, vel, resolvedSemis, when, gateSec); break;
+    case 'snare808': voice = snare808(track.params.snare808,  dest, vel, resolvedSemis, when, gateSec); break;
+    case 'hat808':   voice = hat808(track.params.hat808,      dest, vel, resolvedSemis, when, gateSec); break;
+    case 'clap909':  voice = clap909(track.params.clap909,    dest, vel, resolvedSemis, when, gateSec); break;
+    case 'sampler':  voice = samplerPlay(track.params.sampler,dest, vel, track.sample, resolvedSemis, when, gateSec, options); break;
   }
+  return registerTrackPitchVoice(track, voice, trackPitchSemis);
 }
 
 export function applyMixer(tracks){


### PR DESCRIPTION
### Motivation
- Let the Track FX "Pitch" control affect already-playing voices in realtime instead of only influencing newly-triggered notes by retuning their playback rates when the effect or modulation changes.
- Expose playback handles and playback-rate metadata from sample/engine playback so running voices can be tracked and updated.

### Description
- Add pitch-voice management to `web/tracks.js` including `resolveTrackPitchSemis`, `registerTrackPitchVoice`, and `updateTrackPitchVoices`, and call `updateTrackPitchVoices` from `syncTrackEffects` to retune active voices when track FX values change.
- Change `triggerEngine` in `web/tracks.js` to compute track-level pitch with `resolveTrackPitchSemis`, return engine/sampler voice handles, and register those voices for realtime retuning via `registerTrackPitchVoice`.
- Return voice objects (including a `playbackRate` field) from sample playback paths by updating `web/engine-utils.js` and `web/sampler-engine.js`, and update all engine wrappers in `web/*.js` to propagate those return values so voices can be retuned after start.
- Apply pitch voice updates during transport scheduling by invoking `updateTrackPitchVoices` from `web/main.js` so modulation offsets targeting the pitch FX affect currently playing voices in realtime.

### Testing
- Performed static JS checks with `node --check` on modified files (`web/tracks.js`, `web/main.js`, `web/sampler-engine.js`, `web/engine-utils.js`, `web/engines.js`, `web/synth-engine.js`, `web/juno60-engine.js`, `web/tb303-engine.js`, `web/noise-engine.js`), which completed without errors.
- Ran `git diff --check` to ensure no whitespace/diff issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5d3468ac832da96a512019600386)