### PR TITLE
Replace CVL clip effect sliders with shared Step Effects editor

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -901,9 +901,7 @@ function normalizeTrack(t) {
         const pitch = Number(rawParams.pitch);
         const start = Number(rawParams.start);
         const end = Number(rawParams.end);
-        const drive = Number(rawEffects.drive);
-        const delay = Number(rawEffects.delay);
-        const reverb = Number(rawEffects.reverb);
+        const clipEffects = normalizeStepFx(rawEffects);
         return {
           id: typeof clip.id === 'string' && clip.id.trim() ? clip.id : createCvlClipId(),
           lane: 0,
@@ -917,11 +915,7 @@ function normalizeTrack(t) {
             pan: Number.isFinite(pan) ? Math.max(-1, Math.min(1, pan)) : 0,
             pitch: Number.isFinite(pitch) ? Math.max(-24, Math.min(24, pitch)) : 0,
           },
-          effects: {
-            drive: Number.isFinite(drive) ? Math.max(0, Math.min(1, drive)) : 0,
-            delay: Number.isFinite(delay) ? Math.max(0, Math.min(1, delay)) : 0,
-            reverb: Number.isFinite(reverb) ? Math.max(0, Math.min(1, reverb)) : 0,
-          },
+          effects: clipEffects,
         };
       });
   }
@@ -3252,22 +3246,16 @@ playBtn.onclick = async () => {
               const sampleName = typeof clip.sampleName === 'string' ? clip.sampleName : '';
               const buffer = sampleName ? sampleCache[sampleName] : null;
               if (!buffer) continue;
-              const previousSample = t.sample;
               const previousSamplerParams = { ...(t.params?.sampler || {}) };
               const clipParams = clip.params && typeof clip.params === 'object' ? clip.params : {};
-              t.sample = { buffer, name: sampleName };
               const clipRangeStart = Number(clipParams.start);
               const clipRangeEnd = Number(clipParams.end);
               const clipGain = Number(clipParams.gain);
               const clipPan = Number(clipParams.pan);
               const clipPitch = Number(clipParams.pitch);
-              const clipEffects = clip.effects && typeof clip.effects === 'object' ? clip.effects : {};
-              const clipDrive = Number(clipEffects.drive);
-              const clipDelay = Number(clipEffects.delay);
-              const clipReverb = Number(clipEffects.reverb);
-              if (!t.params || typeof t.params !== 'object') t.params = {};
-              if (!t.params.sampler || typeof t.params.sampler !== 'object') t.params.sampler = {};
-              t.params.sampler = {
+              const clipFx = normalizeStepFx(clip.effects);
+              if (clip.effects !== clipFx) clip.effects = clipFx;
+              const samplerParams = {
                 ...previousSamplerParams,
                 start: Number.isFinite(clipRangeStart) ? Math.max(0, Math.min(1, clipRangeStart)) : 0,
                 end: Number.isFinite(clipRangeEnd) ? Math.max(0, Math.min(1, clipRangeEnd)) : 1,
@@ -3275,15 +3263,36 @@ playBtn.onclick = async () => {
                 semis: Number.isFinite(clipPitch) ? Math.max(-24, Math.min(24, clipPitch)) : 0,
               };
               const durationSec = clipLength * secondsPerBeat;
-              triggerEngine?.(t, 1, 0, scheduledTime, durationSec, {
-                trackPitchSemisOffset,
-                pan: Number.isFinite(clipPan) ? Math.max(-1, Math.min(1, clipPan)) : 0,
-                drive: Number.isFinite(clipDrive) ? Math.max(0, Math.min(1, clipDrive)) : 0,
-                delay: Number.isFinite(clipDelay) ? Math.max(0, Math.min(1, clipDelay)) : 0,
-                reverb: Number.isFinite(clipReverb) ? Math.max(0, Math.min(1, clipReverb)) : 0,
-              });
-              t.params.sampler = previousSamplerParams;
-              t.sample = previousSample;
+              const pan = Number.isFinite(clipPan) ? Math.max(-1, Math.min(1, clipPan)) : 0;
+              const triggerClip = (time, velocity = 1) => {
+                const previousSampleForTrigger = t.sample;
+                const previousParamsForTrigger = { ...(t.params?.sampler || {}) };
+                t.sample = { buffer, name: sampleName };
+                if (!t.params || typeof t.params !== 'object') t.params = {};
+                t.params.sampler = samplerParams;
+                triggerEngine?.(t, velocity, 0, time, durationSec, { trackPitchSemisOffset, pan });
+                t.params.sampler = previousParamsForTrigger;
+                t.sample = previousSampleForTrigger;
+              };
+
+              if (clipFx.type === STEP_FX_TYPES.DUCK || clipFx.type === STEP_FX_TYPES.MULTIBAND_DUCK) {
+                evaluateStepFx(t, { on: true, fx: clipFx }, t.pos, effectOffsets, scheduledTime, tracks, [{ vel: 1, pitch: 0 }], 1, trackPitchSemisOffset);
+              }
+              triggerClip(scheduledTime, 1);
+              if (clipFx.type === STEP_FX_TYPES.DELAY && Number.isFinite(currentStepIntervalMs) && currentStepIntervalMs > 0) {
+                const defaults = STEP_FX_DEFAULTS[STEP_FX_TYPES.DELAY] || {};
+                const offsets = effectOffsets && typeof effectOffsets === 'object'
+                  ? (effectOffsets[STEP_FX_TYPES.DELAY] || effectOffsets[clipFx.type])
+                  : null;
+                const config = resolveDelayConfig({ ...defaults, ...(clipFx.config || {}) }, offsets);
+                for (let i = 0; i < config.repeats; i++) {
+                  const repeatVelocity = config.mix * Math.pow(config.feedback, i);
+                  if (repeatVelocity <= 0.0001) break;
+                  const delayMs = currentStepIntervalMs * config.spacing * (i + 1);
+                  if (!Number.isFinite(delayMs) || delayMs <= 0) continue;
+                  triggerClip(scheduledTime + (delayMs / 1000), repeatVelocity);
+                }
+              }
             }
           }
         } else if (t.mode === 'piano') {

--- a/web/style.css
+++ b/web/style.css
@@ -464,7 +464,8 @@ h3 { margin:0 0 8px; font-weight:600; }
   flex-direction:column;
   gap:8px;
 }
-.cvl-clip-editor-fields .ctrl {
+.cvl-clip-editor-fields .ctrl,
+.cvl-clip-step-fx {
   width:100%;
 }
 .cvl-ruler-track {

--- a/web/ui.js
+++ b/web/ui.js
@@ -2250,7 +2250,6 @@ export function renderParams(containerEl, track, makeFieldHtml) {
     const clips = Array.isArray(t.cvl?.clips) ? t.cvl.clips : [];
     const selectedClip = clips.find((clip) => clip.id === t.cvl?.selectedClipId) || null;
     const selectedClipParams = selectedClip?.params || { start: 0, end: 1, gain: 1, pan: 0, pitch: 0 };
-    const selectedClipEffects = selectedClip?.effects || { drive: 0, delay: 0, reverb: 0 };
     const cvlClipPanel = selectedClip
       ? `
         <div class="cvl-clip-editor-fields">
@@ -2274,18 +2273,9 @@ export function renderParams(containerEl, track, makeFieldHtml) {
             End
             <input id="cvl_clipEnd" type="range" min="0" max="1" step="0.001" value="${selectedClipParams.end}">
           </label>
-          <label class="ctrl">
-            Drive
-            <input id="cvl_clipDrive" type="range" min="0" max="1" step="0.01" value="${selectedClipEffects.drive}">
-          </label>
-          <label class="ctrl">
-            Delay
-            <input id="cvl_clipDelay" type="range" min="0" max="1" step="0.01" value="${selectedClipEffects.delay}">
-          </label>
-          <label class="ctrl">
-            Reverb
-            <input id="cvl_clipReverb" type="range" min="0" max="1" step="0.01" value="${selectedClipEffects.reverb}">
-          </label>
+          <div id="cvl_clipStepFx" class="step-detail cvl-clip-step-fx">
+            <span class="hint">Clip step effects will appear here.</span>
+          </div>
         </div>
       `
       : '<span class="hint">Double tap a left trim handle to edit clip params + effects.</span>';
@@ -2491,6 +2481,25 @@ export function renderParams(containerEl, track, makeFieldHtml) {
     delete containerEl._stepFxEditor;
   }
 
+  const cvlClipStepFxRoot = containerEl.querySelector('#cvl_clipStepFx');
+  const cvlClipStepFxSource = track?.type === 'cvl'
+    ? (Array.isArray(track.cvl?.clips)
+      ? track.cvl.clips.find((clip) => clip.id === track.cvl?.selectedClipId)
+      : null)
+    : null;
+  if (cvlClipStepFxRoot && cvlClipStepFxSource) {
+    cvlClipStepFxSource.fx = normalizeStepFx(cvlClipStepFxSource.effects);
+    cvlClipStepFxSource.effects = cvlClipStepFxSource.fx;
+    const cvlClipFxTrack = { mode: 'steps', steps: [cvlClipStepFxSource] };
+    const cvlClipFxEditor = createStepFxPanel(cvlClipStepFxRoot, cvlClipFxTrack);
+    if (cvlClipFxEditor) {
+      cvlClipFxEditor.updateSelection(0);
+      containerEl._cvlClipFxEditor = cvlClipFxEditor;
+    }
+  } else if (containerEl._cvlClipFxEditor) {
+    delete containerEl._cvlClipFxEditor;
+  }
+
   const trackFxRoot = containerEl.querySelector('#trk_trackFx');
   const trackFxEditor = createTrackFxPanel(trackFxRoot, track);
   if (trackFxEditor) {
@@ -2626,15 +2635,14 @@ export function renderParams(containerEl, track, makeFieldHtml) {
       const currentStart = Number.isFinite(Number(selectedClip.params.start)) ? Number(selectedClip.params.start) : 0;
       selectedClip.params.end = Math.max(next, currentStart);
     });
-    bindClipControl('cvl_clipDrive', (value) => {
-      selectedClip.effects.drive = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
-    });
-    bindClipControl('cvl_clipDelay', (value) => {
-      selectedClip.effects.delay = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
-    });
-    bindClipControl('cvl_clipReverb', (value) => {
-      selectedClip.effects.reverb = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
-    });
+    const cvlClipFxEditor = containerEl._cvlClipFxEditor;
+    if (cvlClipFxEditor && selectedClip) {
+      cvlClipFxEditor.setOnChange(() => {
+        selectedClip.effects = normalizeStepFx(selectedClip.fx);
+        selectedClip.fx = selectedClip.effects;
+        if (typeof onCvlClipChange === 'function') onCvlClipChange();
+      });
+    }
 
     // Engine params
     if (effectiveEngine === 'synth') {


### PR DESCRIPTION
### Motivation
- Unify clip-level effects with the sequencer's step effects UI to reuse existing effect types and defaults for CVL clips.
- Ensure clip effects are normalized through the same model as step effects so playback behavior is consistent with step editing.

### Description
- Replaced the CVL clip Drive/Delay/Reverb range controls in `web/ui.js` with an embedded step-effects panel (`#cvl_clipStepFx`) driven by `createStepFxPanel` so users pick effect type from the shared dropdown and edit effect params via the step UI.
- Normalize and persist clip effects using `normalizeStepFx` when loading/normalizing clips in `web/main.js` and when the embedded editor changes the clip, and wire `setOnChange` to update `selectedClip.effects` and call `onCvlClipChange`.
- During playback, interpret CVL clip effects through the step-effects execution paths by calling `evaluateStepFx` for ducking/multiband duck and by scheduling delayed clip repeats (delay behavior) in `web/main.js` so clip FX behave like step FX.
- Adjusted styles in `web/style.css` (added `.cvl-clip-step-fx`) so the embedded clip step-effects panel spans the clip editor width.

### Testing
- Ran `for f in web/*.js; do node --check "$f" || exit 1; done` which succeeded without syntax errors.
- Ran `git diff --check` which reported no whitespace or diff issues.
- Verified the modified files committed: `web/ui.js`, `web/main.js`, and `web/style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6a24c5bc832da17dd53f9ae9f234)