### PR TITLE
Fix CVL clip effects and ducking

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -1713,7 +1713,7 @@ function renderCvlPanel() {
         lengthBeats: Math.max(minClipLength, 1),
         sampleName,
         params: { start: 0, end: 1, gain: 1, pan: 0, pitch: 0 },
-        effects: { drive: 0, delay: 0, reverb: 0 },
+        effects: normalizeStepFx(),
       };
       if (!Array.isArray(track.cvl.clips)) track.cvl.clips = [];
       track.cvl.clips.push(clip);
@@ -3018,6 +3018,15 @@ function scheduleEnvelope(param, startValue, targetValue, attackSec, holdSec, re
   try { param.linearRampToValueAtTime(startValue, releaseEnd); } catch {}
 }
 
+function getDuckingTargets(tracks, sourceTrack, includeSelf = false) {
+  if (!Array.isArray(tracks) || !tracks.length) return [];
+  return tracks.filter((track) => {
+    if (!track || typeof track !== 'object') return false;
+    if (!includeSelf && sourceTrack && track === sourceTrack) return false;
+    return true;
+  });
+}
+
 function scheduleDucking(tracks, sourceTrack, config, scheduledTime) {
   if (!Array.isArray(tracks) || !tracks.length) return;
   if (!Number.isFinite(currentStepIntervalMs) || currentStepIntervalMs <= 0) return;
@@ -3032,10 +3041,11 @@ function scheduleDucking(tracks, sourceTrack, config, scheduledTime) {
   if (config.depthDb <= 0 || (!attackSec && !holdSec && !releaseSec)) return;
   const targetGain = Math.pow(10, -config.depthDb / 20);
 
-  if (!sourceTrack) return;
-  const duckGain = sourceTrack.duckGainNode?.gain;
-  if (!duckGain) return;
-  scheduleEnvelope(duckGain, 1, targetGain, attackSec, holdSec, releaseSec, startTime);
+  for (const targetTrack of getDuckingTargets(tracks, sourceTrack, config.includeSelf === true)) {
+    const duckGain = targetTrack.duckGainNode?.gain;
+    if (!duckGain) continue;
+    scheduleEnvelope(duckGain, 1, targetGain, attackSec, holdSec, releaseSec, startTime);
+  }
 }
 
 function scheduleMultibandDucking(tracks, sourceTrack, config, scheduledTime) {
@@ -3054,17 +3064,18 @@ function scheduleMultibandDucking(tracks, sourceTrack, config, scheduledTime) {
   const highDb = -Math.max(0, Number(config.highDepthDb) || 0);
   if ((!lowDb && !midDb && !highDb) || (!attackSec && !holdSec && !releaseSec)) return;
 
-  if (!sourceTrack) return;
-  const filters = sourceTrack.duckFilters;
-  if (!filters) return;
-  if (filters.low?.gain) {
-    scheduleEnvelope(filters.low.gain, 0, lowDb, attackSec, holdSec, releaseSec, startTime);
-  }
-  if (filters.mid?.gain) {
-    scheduleEnvelope(filters.mid.gain, 0, midDb, attackSec, holdSec, releaseSec, startTime);
-  }
-  if (filters.high?.gain) {
-    scheduleEnvelope(filters.high.gain, 0, highDb, attackSec, holdSec, releaseSec, startTime);
+  for (const targetTrack of getDuckingTargets(tracks, sourceTrack, config.includeSelf === true)) {
+    const filters = targetTrack.duckFilters;
+    if (!filters) continue;
+    if (filters.low?.gain) {
+      scheduleEnvelope(filters.low.gain, 0, lowDb, attackSec, holdSec, releaseSec, startTime);
+    }
+    if (filters.mid?.gain) {
+      scheduleEnvelope(filters.mid.gain, 0, midDb, attackSec, holdSec, releaseSec, startTime);
+    }
+    if (filters.high?.gain) {
+      scheduleEnvelope(filters.high.gain, 0, highDb, attackSec, holdSec, releaseSec, startTime);
+    }
   }
 }
 

--- a/web/ui.js
+++ b/web/ui.js
@@ -2488,8 +2488,9 @@ export function renderParams(containerEl, track, makeFieldHtml) {
       : null)
     : null;
   if (cvlClipStepFxRoot && cvlClipStepFxSource) {
-    cvlClipStepFxSource.fx = normalizeStepFx(cvlClipStepFxSource.effects);
-    cvlClipStepFxSource.effects = cvlClipStepFxSource.fx;
+    const normalizedClipFx = normalizeStepFx(cvlClipStepFxSource.fx || cvlClipStepFxSource.effects);
+    cvlClipStepFxSource.fx = normalizedClipFx;
+    cvlClipStepFxSource.effects = normalizedClipFx;
     const cvlClipFxTrack = { mode: 'steps', steps: [cvlClipStepFxSource] };
     const cvlClipFxEditor = createStepFxPanel(cvlClipStepFxRoot, cvlClipFxTrack);
     if (cvlClipFxEditor) {
@@ -2637,9 +2638,10 @@ export function renderParams(containerEl, track, makeFieldHtml) {
     });
     const cvlClipFxEditor = containerEl._cvlClipFxEditor;
     if (cvlClipFxEditor && selectedClip) {
-      cvlClipFxEditor.setOnChange(() => {
-        selectedClip.effects = normalizeStepFx(selectedClip.fx);
-        selectedClip.fx = selectedClip.effects;
+      cvlClipFxEditor.setOnChange((index, step) => {
+        const nextFx = normalizeStepFx(step?.fx || selectedClip.fx || selectedClip.effects);
+        selectedClip.fx = nextFx;
+        selectedClip.effects = nextFx;
         if (typeof onCvlClipChange === 'function') onCvlClipChange();
       });
     }


### PR DESCRIPTION
### Motivation
- CVL clips were being initialized with legacy sampler effect fields which caused clip effects to appear "baked in" and not update when switching effect types.
- Editing clip step-FX could leave `fx` and `effects` out of sync, causing the UI and playback to use stale values.
- Ducking only targeted the source track, so clip duck/multiband-duck effects did not affect the rest of the mix or respect the `includeSelf` setting.

### Description
- Initialize newly placed CVL clips with a normalized step-FX state by using `normalizeStepFx()` instead of legacy `{ drive, delay, reverb }` fields in `web/main.js`.
- Keep selected CVL clip `fx` and `effects` synchronized when opening and editing the clip step-FX panel by normalizing and propagating the editor's step state in `web/ui.js`.
- Add `getDuckingTargets()` and update `scheduleDucking()` and `scheduleMultibandDucking()` in `web/main.js` to apply envelopes to all eligible target tracks (respecting `includeSelf`) instead of only the source track.
- Update the CVL clip FX editor callback signature to derive the next normalized FX from the editor-provided `step`, ensuring UI changes write back the normalized shape used by playback.

### Testing
- Ran `node --check web/main.js` and it completed successfully.
- Ran `node --check web/ui.js` and `node --check web/stepfx.js` and both completed successfully.
- Ran `git diff --check` to validate whitespace/format issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf8be8514832d80e54509233cbbae)