### PR TITLE
Fix CVL per-clip effects state

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -124,6 +124,26 @@ const CVL_RATES = [
 ];
 const CVL_SNAP_GRID = 0.25;
 
+function isActiveStepFx(fx) {
+  return !!fx && typeof fx === 'object'
+    && typeof fx.type === 'string'
+    && fx.type.trim().toLowerCase() !== ''
+    && fx.type.trim().toLowerCase() !== 'none';
+}
+
+function resolveClipStepFx(clip) {
+  if (!clip || typeof clip !== 'object') return normalizeStepFx();
+
+  const fromFx = normalizeStepFx(clip.fx);
+  const fromEffects = normalizeStepFx(clip.effects);
+  const resolved = isActiveStepFx(fromFx)
+    ? fromFx
+    : (isActiveStepFx(fromEffects) ? fromEffects : fromFx);
+  clip.fx = resolved;
+  clip.effects = resolved;
+  return resolved;
+}
+
 function createCvlClipId() {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -895,14 +915,12 @@ function normalizeTrack(t) {
           ? Number(clip.lengthBeats)
           : Number(clip.length);
         const rawParams = clip.params && typeof clip.params === 'object' ? clip.params : {};
-        const rawEffects = clip.effects && typeof clip.effects === 'object' ? clip.effects : {};
         const gain = Number(rawParams.gain);
         const pan = Number(rawParams.pan);
         const pitch = Number(rawParams.pitch);
         const start = Number(rawParams.start);
         const end = Number(rawParams.end);
-        const clipEffects = normalizeStepFx(rawEffects);
-        return {
+        const normalizedClip = {
           id: typeof clip.id === 'string' && clip.id.trim() ? clip.id : createCvlClipId(),
           lane: 0,
           startBeat: Number.isFinite(startBeat) ? Math.max(0, startBeat) : 0,
@@ -915,8 +933,11 @@ function normalizeTrack(t) {
             pan: Number.isFinite(pan) ? Math.max(-1, Math.min(1, pan)) : 0,
             pitch: Number.isFinite(pitch) ? Math.max(-24, Math.min(24, pitch)) : 0,
           },
-          effects: clipEffects,
+          fx: normalizeStepFx(clip.fx),
+          effects: normalizeStepFx(clip.effects),
         };
+        resolveClipStepFx(normalizedClip);
+        return normalizedClip;
       });
   }
 
@@ -1713,6 +1734,7 @@ function renderCvlPanel() {
         lengthBeats: Math.max(minClipLength, 1),
         sampleName,
         params: { start: 0, end: 1, gain: 1, pan: 0, pitch: 0 },
+        fx: normalizeStepFx(),
         effects: normalizeStepFx(),
       };
       if (!Array.isArray(track.cvl.clips)) track.cvl.clips = [];
@@ -3264,8 +3286,7 @@ playBtn.onclick = async () => {
               const clipGain = Number(clipParams.gain);
               const clipPan = Number(clipParams.pan);
               const clipPitch = Number(clipParams.pitch);
-              const clipFx = normalizeStepFx(clip.effects);
-              if (clip.effects !== clipFx) clip.effects = clipFx;
+              const clipFx = resolveClipStepFx(clip);
               const samplerParams = {
                 ...previousSamplerParams,
                 start: Number.isFinite(clipRangeStart) ? Math.max(0, Math.min(1, clipRangeStart)) : 0,

--- a/web/ui.js
+++ b/web/ui.js
@@ -18,6 +18,26 @@ const MOD_SOURCES = [
   { value: 'sampleHold', label: 'Sample & Hold' },
 ];
 
+function isActiveStepFx(fx) {
+  return !!fx && typeof fx === 'object'
+    && typeof fx.type === 'string'
+    && fx.type.trim().toLowerCase() !== ''
+    && fx.type.trim().toLowerCase() !== 'none';
+}
+
+function normalizeCvlClipStepFx(clip) {
+  if (!clip || typeof clip !== 'object') return normalizeStepFx();
+
+  const fromFx = normalizeStepFx(clip.fx);
+  const fromEffects = normalizeStepFx(clip.effects);
+  const resolved = isActiveStepFx(fromFx)
+    ? fromFx
+    : (isActiveStepFx(fromEffects) ? fromEffects : fromFx);
+  clip.fx = resolved;
+  clip.effects = resolved;
+  return resolved;
+}
+
 const LFO_SHAPE_OPTIONS = [
   { value: 'sine', label: 'Sine' },
   { value: 'triangle', label: 'Triangle' },
@@ -2488,9 +2508,7 @@ export function renderParams(containerEl, track, makeFieldHtml) {
       : null)
     : null;
   if (cvlClipStepFxRoot && cvlClipStepFxSource) {
-    const normalizedClipFx = normalizeStepFx(cvlClipStepFxSource.fx || cvlClipStepFxSource.effects);
-    cvlClipStepFxSource.fx = normalizedClipFx;
-    cvlClipStepFxSource.effects = normalizedClipFx;
+    normalizeCvlClipStepFx(cvlClipStepFxSource);
     const cvlClipFxTrack = { mode: 'steps', steps: [cvlClipStepFxSource] };
     const cvlClipFxEditor = createStepFxPanel(cvlClipStepFxRoot, cvlClipFxTrack);
     if (cvlClipFxEditor) {
@@ -2639,9 +2657,10 @@ export function renderParams(containerEl, track, makeFieldHtml) {
     const cvlClipFxEditor = containerEl._cvlClipFxEditor;
     if (cvlClipFxEditor && selectedClip) {
       cvlClipFxEditor.setOnChange((index, step) => {
-        const nextFx = normalizeStepFx(step?.fx || selectedClip.fx || selectedClip.effects);
-        selectedClip.fx = nextFx;
-        selectedClip.effects = nextFx;
+        if (step && typeof step === 'object') {
+          selectedClip.fx = step.fx;
+        }
+        normalizeCvlClipStepFx(selectedClip);
         if (typeof onCvlClipChange === 'function') onCvlClipChange();
       });
     }


### PR DESCRIPTION
### Motivation
- CVL clips could have stale or duplicated effect state in `fx` vs `effects`, causing active per-clip step effects to be ignored or overwritten during editing and playback.  
- The UI and playback logic needed a single resolution step so editor changes and scheduling use the same effective step-fx object.

### Description
- Added helpers to resolve and detect active per-step effects (`isActiveStepFx`, `resolveClipStepFx` in `web/main.js`, and `normalizeCvlClipStepFx` in `web/ui.js`).  
- Preserve and normalize both `fx` and `effects` for CVL clips when normalizing tracks and when creating new clips (initialize `fx` and `effects` fields).  
- Playback now resolves the clip's effective step-fx via `resolveClipStepFx` before triggering the sampler, and uses the resolved fx to run ducking/delay logic and to schedule repeats.  
- The CVL clip effect editor now normalizes from either field before rendering and on change so editor edits are saved to the resolved per-clip step-fx state (`web/ui.js` changes), replacing the previous baked-in drive/delay/reverb sliders with the step effects panel.

### Testing
- Performed static syntax checks: `node --check web/main.js && node --check web/ui.js && node --check web/stepfx.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfb622fe4832db673fdda040098ba)