### PR TITLE
Add realtime per-clip CVL effects

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -83,6 +83,7 @@ let isStepMultiSelectMode = false;
 
 const sampleCache = {};
 const sampleWaveformCache = new Map();
+const activeCvlClipVoices = new Map();
 const song = {
   patterns: [],
   current: 0,
@@ -166,6 +167,55 @@ function getCvlScrubberOffset(trackLengthBeats, elapsedSeconds, rateSeconds, dep
   const phase = (elapsedSeconds / rateSeconds) % 1;
   const smooth = Math.sin(phase * Math.PI * 2);
   return smooth * depth * trackLengthBeats;
+}
+
+function clampCvlClipEffectValue(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.max(0, Math.min(1, num));
+}
+
+function getCvlClipRealtimeEffects(clip) {
+  const params = clip?.params && typeof clip.params === 'object' ? clip.params : {};
+  return {
+    pan: Number.isFinite(Number(params.pan)) ? Math.max(-1, Math.min(1, Number(params.pan))) : 0,
+    drive: clampCvlClipEffectValue(params.drive),
+    delay: clampCvlClipEffectValue(params.delay),
+    reverb: clampCvlClipEffectValue(params.reverb),
+  };
+}
+
+function registerActiveCvlClipVoice(clip, voice) {
+  if (!clip?.id || !voice) return;
+  const entry = { clipId: clip.id, voice };
+  const voices = activeCvlClipVoices.get(clip.id) || [];
+  voices.push(entry);
+  activeCvlClipVoices.set(clip.id, voices);
+
+  const source = voice.source || voice.src || null;
+  if (source) {
+    const previousOnEnded = source.onended;
+    source.onended = (...args) => {
+      const currentVoices = activeCvlClipVoices.get(clip.id) || [];
+      const index = currentVoices.indexOf(entry);
+      if (index >= 0) currentVoices.splice(index, 1);
+      if (currentVoices.length) activeCvlClipVoices.set(clip.id, currentVoices);
+      else activeCvlClipVoices.delete(clip.id);
+      if (typeof previousOnEnded === 'function') previousOnEnded.apply(source, args);
+    };
+  }
+}
+
+function updateActiveCvlClipEffects(clip) {
+  if (!clip?.id) return;
+  const voices = activeCvlClipVoices.get(clip.id);
+  if (!Array.isArray(voices) || !voices.length) return;
+  const effects = getCvlClipRealtimeEffects(clip);
+  for (const entry of voices) {
+    if (typeof entry?.voice?.setClipEffects === 'function') {
+      entry.voice.setClipEffects(effects, ctx.currentTime);
+    }
+  }
 }
 
 function shuffleArray(source) {
@@ -920,6 +970,9 @@ function normalizeTrack(t) {
         const pitch = Number(rawParams.pitch);
         const start = Number(rawParams.start);
         const end = Number(rawParams.end);
+        const drive = Number(rawParams.drive);
+        const delay = Number(rawParams.delay);
+        const reverb = Number(rawParams.reverb);
         const normalizedClip = {
           id: typeof clip.id === 'string' && clip.id.trim() ? clip.id : createCvlClipId(),
           lane: 0,
@@ -932,6 +985,9 @@ function normalizeTrack(t) {
             gain: Number.isFinite(gain) ? Math.max(0, Math.min(2, gain)) : 1,
             pan: Number.isFinite(pan) ? Math.max(-1, Math.min(1, pan)) : 0,
             pitch: Number.isFinite(pitch) ? Math.max(-24, Math.min(24, pitch)) : 0,
+            drive: clampCvlClipEffectValue(drive),
+            delay: clampCvlClipEffectValue(delay),
+            reverb: clampCvlClipEffectValue(reverb),
           },
           fx: normalizeStepFx(clip.fx),
           effects: normalizeStepFx(clip.effects),
@@ -1491,6 +1547,10 @@ function renderParamsPanel(){
       saveProjectToStorage();
     },
     onCvlClipChange: () => {
+      const selectedClip = Array.isArray(track.cvl?.clips)
+        ? track.cvl.clips.find((clip) => clip.id === track.cvl?.selectedClipId)
+        : null;
+      updateActiveCvlClipEffects(selectedClip);
       saveProjectToStorage();
     },
     onParamsRerender: () => {
@@ -1733,7 +1793,7 @@ function renderCvlPanel() {
         startBeat: clippedStart,
         lengthBeats: Math.max(minClipLength, 1),
         sampleName,
-        params: { start: 0, end: 1, gain: 1, pan: 0, pitch: 0 },
+        params: { start: 0, end: 1, gain: 1, pan: 0, pitch: 0, drive: 0, delay: 0, reverb: 0 },
         fx: normalizeStepFx(),
         effects: normalizeStepFx(),
       };
@@ -3286,6 +3346,7 @@ playBtn.onclick = async () => {
               const clipGain = Number(clipParams.gain);
               const clipPan = Number(clipParams.pan);
               const clipPitch = Number(clipParams.pitch);
+              const clipRealtimeEffects = getCvlClipRealtimeEffects(clip);
               const clipFx = resolveClipStepFx(clip);
               const samplerParams = {
                 ...previousSamplerParams,
@@ -3302,7 +3363,15 @@ playBtn.onclick = async () => {
                 t.sample = { buffer, name: sampleName };
                 if (!t.params || typeof t.params !== 'object') t.params = {};
                 t.params.sampler = samplerParams;
-                triggerEngine?.(t, velocity, 0, time, durationSec, { trackPitchSemisOffset, pan });
+                const voice = triggerEngine?.(t, velocity, 0, time, durationSec, {
+                  trackPitchSemisOffset,
+                  pan,
+                  drive: clipRealtimeEffects.drive,
+                  delay: clipRealtimeEffects.delay,
+                  reverb: clipRealtimeEffects.reverb,
+                  realtimeEffects: true,
+                });
+                registerActiveCvlClipVoice(clip, voice);
                 t.params.sampler = previousParamsForTrigger;
                 t.sample = previousSampleForTrigger;
               };

--- a/web/sampler-engine.js
+++ b/web/sampler-engine.js
@@ -1,6 +1,17 @@
 import { ctx } from './core.js';
 import { applyDeclickEnvelope } from './engine-utils.js';
 
+function createDriveCurve(drive) {
+  const amount = 1 + Math.max(0, Math.min(1, Number(drive) || 0)) * 25;
+  const samples = 2048;
+  const curve = new Float32Array(samples);
+  for (let i = 0; i < samples; i++) {
+    const x = (i * 2) / (samples - 1) - 1;
+    curve[i] = ((1 + amount) * x) / (1 + amount * Math.abs(x));
+  }
+  return curve;
+}
+
 export function samplerPlay(p, dest, vel = 1, sample, semis = 0, when, durationSec, options = {}) {
   if (!sample?.buffer) return;
   const startTime = Number.isFinite(when) ? when : ctx.currentTime;
@@ -30,29 +41,24 @@ export function samplerPlay(p, dest, vel = 1, sample, semis = 0, when, durationS
   const drive = Number(options.drive);
   const delay = Number(options.delay);
   const reverb = Number(options.reverb);
+  const realtimeEffects = options.realtimeEffects === true;
 
   let finalNode = vca;
   let panner = null;
-  if (Number.isFinite(pan)) {
+  if (Number.isFinite(pan) || realtimeEffects) {
     try {
       panner = ctx.createStereoPanner();
-      panner.pan.setValueAtTime(Math.max(-1, Math.min(1, pan)), startTime);
+      panner.pan.setValueAtTime(Number.isFinite(pan) ? Math.max(-1, Math.min(1, pan)) : 0, startTime);
       finalNode.connect(panner);
       finalNode = panner;
     } catch {}
   }
 
   const clipDrive = Number.isFinite(drive) ? Math.max(0, Math.min(1, drive)) : 0;
-  if (clipDrive > 0.001) {
-    const shaper = ctx.createWaveShaper();
-    const amount = 1 + clipDrive * 25;
-    const samples = 2048;
-    const curve = new Float32Array(samples);
-    for (let i = 0; i < samples; i++) {
-      const x = (i * 2) / (samples - 1) - 1;
-      curve[i] = ((1 + amount) * x) / (1 + amount * Math.abs(x));
-    }
-    shaper.curve = curve;
+  let shaper = null;
+  if (clipDrive > 0.001 || realtimeEffects) {
+    shaper = ctx.createWaveShaper();
+    shaper.curve = createDriveCurve(clipDrive);
     shaper.oversample = '2x';
     finalNode.connect(shaper);
     finalNode = shaper;
@@ -61,23 +67,27 @@ export function samplerPlay(p, dest, vel = 1, sample, semis = 0, when, durationS
   finalNode.connect(target);
 
   const clipDelay = Number.isFinite(delay) ? Math.max(0, Math.min(1, delay)) : 0;
-  if (clipDelay > 0.001) {
-    const delayNode = ctx.createDelay(0.6);
-    const feedback = ctx.createGain();
-    const wet = ctx.createGain();
+  let delayNode = null;
+  let delayFeedback = null;
+  let delayWet = null;
+  if (clipDelay > 0.001 || realtimeEffects) {
+    delayNode = ctx.createDelay(0.6);
+    delayFeedback = ctx.createGain();
+    delayWet = ctx.createGain();
     delayNode.delayTime.setValueAtTime(0.08 + clipDelay * 0.32, startTime);
-    feedback.gain.setValueAtTime(0.15 + clipDelay * 0.45, startTime);
-    wet.gain.setValueAtTime(clipDelay * 0.45, startTime);
+    delayFeedback.gain.setValueAtTime(0.15 + clipDelay * 0.45, startTime);
+    delayWet.gain.setValueAtTime(clipDelay * 0.45, startTime);
     finalNode.connect(delayNode);
-    delayNode.connect(feedback);
-    feedback.connect(delayNode);
-    delayNode.connect(wet).connect(target);
+    delayNode.connect(delayFeedback);
+    delayFeedback.connect(delayNode);
+    delayNode.connect(delayWet).connect(target);
   }
 
   const clipReverb = Number.isFinite(reverb) ? Math.max(0, Math.min(1, reverb)) : 0;
-  if (clipReverb > 0.001) {
+  let reverbWet = null;
+  if (clipReverb > 0.001 || realtimeEffects) {
     const convolver = ctx.createConvolver();
-    const wet = ctx.createGain();
+    reverbWet = ctx.createGain();
     const irLen = Math.max(1, Math.floor(ctx.sampleRate * 0.35));
     const ir = ctx.createBuffer(1, irLen, ctx.sampleRate);
     const data = ir.getChannelData(0);
@@ -86,9 +96,9 @@ export function samplerPlay(p, dest, vel = 1, sample, semis = 0, when, durationS
       data[i] = (Math.random() * 2 - 1) * decay;
     }
     convolver.buffer = ir;
-    wet.gain.setValueAtTime(clipReverb * 0.5, startTime);
+    reverbWet.gain.setValueAtTime(clipReverb * 0.5, startTime);
     finalNode.connect(convolver);
-    convolver.connect(wet).connect(target);
+    convolver.connect(reverbWet).connect(target);
   }
 
   src.connect(vca);
@@ -99,9 +109,32 @@ export function samplerPlay(p, dest, vel = 1, sample, semis = 0, when, durationS
   applyDeclickEnvelope(vca, (p.gain ?? 1) * vel, startTime, duration);
   src.start(startTime, startSec, duration);
   src.stop(startTime + duration + 0.005);
+  const setClipEffects = (next = {}, whenTime = ctx.currentTime) => {
+    const effectTime = Number.isFinite(whenTime) ? whenTime : ctx.currentTime;
+    const nextPan = Number(next.pan);
+    if (panner?.pan && Number.isFinite(nextPan)) {
+      try { panner.pan.setTargetAtTime(Math.max(-1, Math.min(1, nextPan)), effectTime, 0.01); } catch {}
+    }
+    const nextDrive = Number(next.drive);
+    if (shaper && Number.isFinite(nextDrive)) {
+      shaper.curve = createDriveCurve(nextDrive);
+    }
+    const nextDelay = Number(next.delay);
+    if (delayNode && delayFeedback && delayWet && Number.isFinite(nextDelay)) {
+      const clamped = Math.max(0, Math.min(1, nextDelay));
+      try { delayNode.delayTime.setTargetAtTime(0.08 + clamped * 0.32, effectTime, 0.02); } catch {}
+      try { delayFeedback.gain.setTargetAtTime(0.15 + clamped * 0.45, effectTime, 0.02); } catch {}
+      try { delayWet.gain.setTargetAtTime(clamped * 0.45, effectTime, 0.02); } catch {}
+    }
+    const nextReverb = Number(next.reverb);
+    if (reverbWet && Number.isFinite(nextReverb)) {
+      try { reverbWet.gain.setTargetAtTime(Math.max(0, Math.min(1, nextReverb)) * 0.5, effectTime, 0.02); } catch {}
+    }
+  };
+
   src.onended = () => {
     try { src.disconnect(); } catch {}
     try { vca.disconnect(); } catch {}
   };
-  return { source: src, gain: vca, playbackRate: rate };
+  return { source: src, gain: vca, playbackRate: rate, setClipEffects };
 }

--- a/web/ui.js
+++ b/web/ui.js
@@ -2269,7 +2269,7 @@ export function renderParams(containerEl, track, makeFieldHtml) {
   if (t.type === 'cvl') {
     const clips = Array.isArray(t.cvl?.clips) ? t.cvl.clips : [];
     const selectedClip = clips.find((clip) => clip.id === t.cvl?.selectedClipId) || null;
-    const selectedClipParams = selectedClip?.params || { start: 0, end: 1, gain: 1, pan: 0, pitch: 0 };
+    const selectedClipParams = selectedClip?.params || { start: 0, end: 1, gain: 1, pan: 0, pitch: 0, drive: 0, delay: 0, reverb: 0 };
     const cvlClipPanel = selectedClip
       ? `
         <div class="cvl-clip-editor-fields">
@@ -2284,6 +2284,18 @@ export function renderParams(containerEl, track, makeFieldHtml) {
           <label class="ctrl">
             Pitch
             <input id="cvl_clipPitch" type="range" min="-24" max="24" step="1" value="${selectedClipParams.pitch}">
+          </label>
+          <label class="ctrl">
+            Drive
+            <input id="cvl_clipDrive" type="range" min="0" max="1" step="0.01" value="${selectedClipParams.drive ?? 0}">
+          </label>
+          <label class="ctrl">
+            Delay
+            <input id="cvl_clipDelay" type="range" min="0" max="1" step="0.01" value="${selectedClipParams.delay ?? 0}">
+          </label>
+          <label class="ctrl">
+            Reverb
+            <input id="cvl_clipReverb" type="range" min="0" max="1" step="0.01" value="${selectedClipParams.reverb ?? 0}">
           </label>
           <label class="ctrl">
             Start
@@ -2630,6 +2642,7 @@ export function renderParams(containerEl, track, makeFieldHtml) {
       if (!control || !selectedClip) return;
       control.oninput = (ev) => {
         updater(Number(ev.target.value));
+        if (typeof onCvlClipChange === 'function') onCvlClipChange();
       };
       control.onchange = () => {
         if (typeof onCvlClipChange === 'function') onCvlClipChange();
@@ -2643,6 +2656,15 @@ export function renderParams(containerEl, track, makeFieldHtml) {
     });
     bindClipControl('cvl_clipPitch', (value) => {
       selectedClip.params.pitch = Number.isFinite(value) ? Math.max(-24, Math.min(24, value)) : 0;
+    });
+    bindClipControl('cvl_clipDrive', (value) => {
+      selectedClip.params.drive = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
+    });
+    bindClipControl('cvl_clipDelay', (value) => {
+      selectedClip.params.delay = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
+    });
+    bindClipControl('cvl_clipReverb', (value) => {
+      selectedClip.params.reverb = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
     });
     bindClipControl('cvl_clipStart', (value) => {
       const next = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;


### PR DESCRIPTION
### Motivation
- Enable per-clip effect controls in the CVL workflow so clip-level Drive/Delay/Reverb can be edited while audio is playing and applied in realtime.

### Description
- Added normalized per-clip effect params (`drive`, `delay`, `reverb`) with clamping and sensible defaults when clips are created or loaded (`web/main.js` changes to normalization and CVL defaults).
- Exposed Drive/Delay/Reverb sliders in the CVL clip params editor and wired inputs to update clip params immediately (`web/ui.js`).
- Extended sampler playback to support realtime effect nodes (pan, waveshaper drive, delay, convolver reverb) and return a `setClipEffects` updater so running voices can be adjusted live (`web/sampler-engine.js`).
- Tracked active CVL clip voices in a map and registered voices on trigger so edits to the selected clip call `setClipEffects` on currently playing voices; added helpers to compute and push per-clip realtime effect state (`web/main.js`).
- When triggering CVL clips, per-clip realtime effect values are passed to `triggerEngine` and voices are registered for live updates (`web/main.js`).

### Testing
- Ran syntax checks: `node --check web/main.js && node --check web/ui.js && node --check web/sampler-engine.js` (passed).
- Ran `git diff --check` and `git diff --stat` to validate diff cleanliness (no issues reported).
- Attempted browser-based screenshot/test command (`test -n "$(which chromium || which chromium-browser || which google-chrome)"`) but no browser binary was available in the environment (not applicable here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e826cf24832db658d332cf2bdd2f)